### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,5 +1,8 @@
 name: Lint Code with golangci-lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/cisco-ios-xe-wireless-go/security/code-scanning/3](https://github.com/umatare5/cisco-ios-xe-wireless-go/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only needs to read the repository contents (e.g., to lint the code), we will set `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the minimal required permissions unless explicitly overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
