### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,7 @@
 name: Release Library as Artifacts
+permissions:
+  contents: read
+  packages: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/cisco-ios-xe-wireless-go/security/code-scanning/2](https://github.com/umatare5/cisco-ios-xe-wireless-go/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `contents: read` permission is needed for the `actions/checkout` step to fetch the repository code.
- The `packages: write` permission is required for the `docker/login-action` and `goreleaser/goreleaser-action` steps to interact with the GitHub Container Registry and release artifacts.

The `permissions` block will be added after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
