### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - VERSION
 
+permissions:
+  contents: write
+
 jobs:
   update-tag:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/cisco-ios-xe-wireless-go/security/code-scanning/1](https://github.com/umatare5/cisco-ios-xe-wireless-go/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to explicitly define the required permissions. Since the workflow needs to push tags, it requires `contents: write` permission. This ensures that the workflow has only the necessary permissions and nothing more.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. This is the most efficient approach since the workflow contains only one job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
