### PR TITLE
Repair the AP and RF tag write paths and preserve unnamed leaves

### DIFF
--- a/service/ap/rpc_payload.go
+++ b/service/ap/rpc_payload.go
@@ -32,6 +32,9 @@ type APCfgApTagData struct {
 	SiteTag   string `json:"site-tag"`   // Site tag assigned to the AP
 	PolicyTag string `json:"policy-tag"` // Policy tag assigned to the AP
 	RFTag     string `json:"rf-tag"`     // RF tag assigned to the AP
+	// PrimingProfile is carried so the replacing write does not drop an assignment the caller
+	// never named; it is omitted unless the read that precedes the write returned one.
+	PrimingProfile string `json:"priming-profile,omitempty"`
 }
 
 // APConfigRPCInput represents input structure for AP configuration RPC calls.

--- a/service/ap/service.go
+++ b/service/ap/service.go
@@ -933,14 +933,43 @@ func (s Service) assignTags(ctx context.Context, apMAC string, tags ApTag) error
 	if err != nil {
 		return fmt.Errorf("invalid AP MAC address %s: %w", apMAC, err)
 	}
+	tagData, err := s.resolveAPTagData(ctx, normalizedMAC, tags)
+	if err != nil {
+		return err
+	}
 	url := s.Client().RESTCONFBuilder().BuildQueryURL(routes.APTagPath, normalizedMAC)
-	tagData := buildAPCfgApTagData(normalizedMAC, tags)
 
 	// Execute operation with direct error propagation
 	if err := core.PutVoid(ctx, s.Client(), url, APTagPayload{ApTag: tagData}); err != nil {
 		return ierrors.ServiceOperationError("assign", "AP", "tags", err)
 	}
 	return nil
+}
+
+// resolveAPTagData returns the entry to write. The request replaces the whole entry, so a tag
+// the caller did not name is carried over from the AP's current one; the defaults apply only
+// where the AP has no entry to carry over.
+func (s Service) resolveAPTagData(
+	ctx context.Context,
+	normalizedMAC string,
+	tags ApTag,
+) (APCfgApTagData, error) {
+	current, err := s.GetTagConfigByMAC(ctx, normalizedMAC)
+	if err != nil && !core.IsNotFoundError(err) {
+		return APCfgApTagData{}, ierrors.ServiceOperationError("assign", "AP", "tags", err)
+	}
+	if err != nil || current == nil || len(current.ApTag) == 0 {
+		return buildAPCfgApTagData(normalizedMAC, tags), nil
+	}
+
+	// A tag holding its default is omitted from the read, so the carried-over value still goes
+	// through the defaults: the controller rejects a payload naming a tag with an empty string.
+	existing := current.ApTag[0]
+	return buildAPCfgApTagData(normalizedMAC, ApTag{
+		SiteTag:   validation.SelectNonEmptyValue(tags.SiteTag, existing.SiteTag),
+		PolicyTag: validation.SelectNonEmptyValue(tags.PolicyTag, existing.PolicyTag),
+		RFTag:     validation.SelectNonEmptyValue(tags.RFTag, existing.RFTag),
+	}), nil
 }
 
 // reload is the internal helper function for AP reload operations.

--- a/service/ap/service.go
+++ b/service/ap/service.go
@@ -966,9 +966,10 @@ func (s Service) resolveAPTagData(
 	// through the defaults: the controller rejects a payload naming a tag with an empty string.
 	existing := current.ApTag[0]
 	return buildAPCfgApTagData(normalizedMAC, ApTag{
-		SiteTag:   validation.SelectNonEmptyValue(tags.SiteTag, existing.SiteTag),
-		PolicyTag: validation.SelectNonEmptyValue(tags.PolicyTag, existing.PolicyTag),
-		RFTag:     validation.SelectNonEmptyValue(tags.RFTag, existing.RFTag),
+		SiteTag:        validation.SelectNonEmptyValue(tags.SiteTag, existing.SiteTag),
+		PolicyTag:      validation.SelectNonEmptyValue(tags.PolicyTag, existing.PolicyTag),
+		RFTag:          validation.SelectNonEmptyValue(tags.RFTag, existing.RFTag),
+		PrimingProfile: existing.PrimingProfile,
 	}), nil
 }
 
@@ -998,9 +999,10 @@ func findAPByMAC(capwapData *CiscoIOSXEWirelessApOperCAPWAPData, apMAC string) (
 // buildAPCfgApTagData constructs the payload for tag assignment requests.
 func buildAPCfgApTagData(normalizedMAC string, tags ApTag) APCfgApTagData {
 	return APCfgApTagData{
-		APMac:     normalizedMAC,
-		SiteTag:   validation.SelectNonEmptyValue(tags.SiteTag, validation.DefaultSiteTag),
-		PolicyTag: validation.SelectNonEmptyValue(tags.PolicyTag, validation.DefaultPolicyTag),
-		RFTag:     validation.SelectNonEmptyValue(tags.RFTag, validation.DefaultRFTag),
+		APMac:          normalizedMAC,
+		SiteTag:        validation.SelectNonEmptyValue(tags.SiteTag, validation.DefaultSiteTag),
+		PolicyTag:      validation.SelectNonEmptyValue(tags.PolicyTag, validation.DefaultPolicyTag),
+		RFTag:          validation.SelectNonEmptyValue(tags.RFTag, validation.DefaultRFTag),
+		PrimingProfile: tags.PrimingProfile,
 	}
 }

--- a/service/ap/service.go
+++ b/service/ap/service.go
@@ -937,7 +937,7 @@ func (s Service) assignTags(ctx context.Context, apMAC string, tags ApTag) error
 	if err != nil {
 		return err
 	}
-	url := s.Client().RESTCONFBuilder().BuildQueryURL(routes.APTagPath, normalizedMAC)
+	url := s.Client().RESTCONFBuilder().BuildQueryURL(routes.APTagQueryPath, normalizedMAC)
 
 	// Execute operation with direct error propagation
 	if err := core.PutVoid(ctx, s.Client(), url, APTagPayload{ApTag: tagData}); err != nil {

--- a/service/ap/service_test.go
+++ b/service/ap/service_test.go
@@ -1,6 +1,13 @@
 package ap_test
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/umatare5/cisco-ios-xe-wireless-go/internal/core"
@@ -2160,4 +2167,185 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 			t.Error("Expected error for failed tag assignment RPC call, got nil")
 		}
 	})
+}
+
+// tagRecorder captures the body of the write a tag assignment sent. The mocks in pkg/testutil
+// record the method, path and query of a request but not its body, which is what decides
+// whether a tag the caller did not name survived.
+type tagRecorder struct {
+	mu   sync.Mutex
+	body string
+}
+
+func (r *tagRecorder) set(body string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.body = body
+}
+
+// written returns the three tags the recorded write carried.
+func (r *tagRecorder) written(t *testing.T) (siteTag, policyTag, rfTag string) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.body == "" {
+		t.Fatal("no write reached the server")
+	}
+
+	var payload struct {
+		ApTag struct {
+			SiteTag   string `json:"site-tag"`
+			PolicyTag string `json:"policy-tag"`
+			RFTag     string `json:"rf-tag"`
+		} `json:"Cisco-IOS-XE-wireless-ap-cfg:ap-tag"`
+	}
+	if err := json.Unmarshal([]byte(r.body), &payload); err != nil {
+		t.Fatalf("Failed to decode the recorded write: %v", err)
+	}
+	return payload.ApTag.SiteTag, payload.ApTag.PolicyTag, payload.ApTag.RFTag
+}
+
+// newTagRecorderService answers a tag read with entry and records the write that follows. An
+// empty entry makes the read a 404, which is the AP-has-no-entry case.
+func newTagRecorderService(t *testing.T, entry string) (ap.Service, *tagRecorder) {
+	t.Helper()
+
+	recorder := &tagRecorder{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if entry == "" {
+				http.NotFound(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(entry))
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Failed to read the request body: %v", err)
+		}
+		recorder.set(string(body))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse the test server URL: %v", err)
+	}
+
+	client, err := core.New(parsed.Host, "test-token", core.WithInsecureSkipVerify(true))
+	if err != nil {
+		t.Fatalf("Failed to create the client: %v", err)
+	}
+
+	return ap.NewService(client), recorder
+}
+
+const testAPTagEntry = `{
+	"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
+		"ap-mac": "aa:bb:cc:dd:ee:ff",
+		"site-tag": "existing-site",
+		"policy-tag": "existing-policy",
+		"rf-tag": "existing-rf"
+	}]
+}`
+
+// testAPTagEntryAtDefault is the entry of an AP whose policy and RF tags hold their default, which
+// the controller omits from the read.
+const testAPTagEntryAtDefault = `{
+	"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
+		"ap-mac": "aa:bb:cc:dd:ee:ff",
+		"site-tag": "existing-site"
+	}]
+}`
+
+// TestApServiceUnit_AssignTags_MergeSemantics tests that a tag assignment preserves the tags
+// the caller did not name, because the write replaces the whole entry.
+func TestApServiceUnit_AssignTags_MergeSemantics(t *testing.T) {
+	const apMAC = "aa:bb:cc:dd:ee:ff"
+
+	tests := []struct {
+		name              string
+		entry             string
+		assign            func(ctx context.Context, s ap.Service) error
+		expectedSiteTag   string
+		expectedPolicyTag string
+		expectedRFTag     string
+	}{
+		{
+			name:  "site tag assignment keeps the other two",
+			entry: testAPTagEntry,
+			assign: func(ctx context.Context, s ap.Service) error {
+				return s.AssignSiteTag(ctx, apMAC, "new-site")
+			},
+			expectedSiteTag:   "new-site",
+			expectedPolicyTag: "existing-policy",
+			expectedRFTag:     "existing-rf",
+		},
+		{
+			name:  "policy tag assignment keeps the other two",
+			entry: testAPTagEntry,
+			assign: func(ctx context.Context, s ap.Service) error {
+				return s.AssignPolicyTag(ctx, apMAC, "new-policy")
+			},
+			expectedSiteTag:   "existing-site",
+			expectedPolicyTag: "new-policy",
+			expectedRFTag:     "existing-rf",
+		},
+		{
+			name:  "RF tag assignment keeps the other two",
+			entry: testAPTagEntry,
+			assign: func(ctx context.Context, s ap.Service) error {
+				return s.AssignRFTag(ctx, apMAC, "new-rf")
+			},
+			expectedSiteTag:   "existing-site",
+			expectedPolicyTag: "existing-policy",
+			expectedRFTag:     "new-rf",
+		},
+		{
+			name:  "a tag the read omits falls back to its default, not an empty leaf",
+			entry: testAPTagEntryAtDefault,
+			assign: func(ctx context.Context, s ap.Service) error {
+				return s.AssignPolicyTag(ctx, apMAC, "new-policy")
+			},
+			expectedSiteTag:   "existing-site",
+			expectedPolicyTag: "new-policy",
+			expectedRFTag:     "default-rf-tag",
+		},
+		{
+			name:  "no entry falls back to the defaults",
+			entry: "",
+			assign: func(ctx context.Context, s ap.Service) error {
+				return s.AssignSiteTag(ctx, apMAC, "new-site")
+			},
+			expectedSiteTag:   "new-site",
+			expectedPolicyTag: "default-policy-tag",
+			expectedRFTag:     "default-rf-tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, recorder := newTagRecorderService(t, tt.entry)
+
+			if err := tt.assign(context.Background(), service); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			siteTag, policyTag, rfTag := recorder.written(t)
+			if siteTag != tt.expectedSiteTag {
+				t.Errorf("site-tag = %q, want %q", siteTag, tt.expectedSiteTag)
+			}
+			if policyTag != tt.expectedPolicyTag {
+				t.Errorf("policy-tag = %q, want %q", policyTag, tt.expectedPolicyTag)
+			}
+			if rfTag != tt.expectedRFTag {
+				t.Errorf("rf-tag = %q, want %q", rfTag, tt.expectedRFTag)
+			}
+		})
+	}
 }

--- a/service/ap/service_test.go
+++ b/service/ap/service_test.go
@@ -2213,6 +2213,27 @@ func (r *tagRecorder) written(t *testing.T) (siteTag, policyTag, rfTag string) {
 	return payload.ApTag.SiteTag, payload.ApTag.PolicyTag, payload.ApTag.RFTag
 }
 
+// primingProfile returns the priming profile the recorded write carried.
+func (r *tagRecorder) primingProfile(t *testing.T) string {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.body == "" {
+		t.Fatal("no write reached the server")
+	}
+
+	var payload struct {
+		ApTag struct {
+			PrimingProfile string `json:"priming-profile"`
+		} `json:"Cisco-IOS-XE-wireless-ap-cfg:ap-tag"`
+	}
+	if err := json.Unmarshal([]byte(r.body), &payload); err != nil {
+		t.Fatalf("Failed to decode the recorded write: %v", err)
+	}
+	return payload.ApTag.PrimingProfile
+}
+
 // newTagRecorderService answers a tag read with entry and records the write that follows. An
 // empty entry makes the read a 404, which is the AP-has-no-entry case.
 func newTagRecorderService(t *testing.T, entry string) (ap.Service, *tagRecorder) {
@@ -2355,4 +2376,41 @@ func TestApServiceUnit_AssignTags_MergeSemantics(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestApServiceUnit_AssignTags_KeepsPrimingProfile tests that the replacing write carries a
+// priming profile the caller never named, which the write body did not declare before.
+func TestApServiceUnit_AssignTags_KeepsPrimingProfile(t *testing.T) {
+	const apMAC = "aa:bb:cc:dd:ee:ff"
+	const entry = `{
+		"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
+			"ap-mac": "aa:bb:cc:dd:ee:ff",
+			"site-tag": "existing-site",
+			"policy-tag": "existing-policy",
+			"rf-tag": "existing-rf",
+			"priming-profile": "existing-priming"
+		}]
+	}`
+
+	t.Run("an existing priming profile survives", func(t *testing.T) {
+		service, recorder := newTagRecorderService(t, entry)
+
+		if err := service.AssignSiteTag(context.Background(), apMAC, "new-site"); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if got := recorder.primingProfile(t); got != "existing-priming" {
+			t.Errorf("priming-profile = %q, want %q", got, "existing-priming")
+		}
+	})
+
+	t.Run("no priming profile is invented", func(t *testing.T) {
+		service, recorder := newTagRecorderService(t, testAPTagEntry)
+
+		if err := service.AssignSiteTag(context.Background(), apMAC, "new-site"); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if got := recorder.primingProfile(t); got != "" {
+			t.Errorf("priming-profile = %q, want it absent", got)
+		}
+	})
 }

--- a/service/ap/service_test.go
+++ b/service/ap/service_test.go
@@ -1861,7 +1861,14 @@ func TestApServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-cfg-rpc:set-ap-admin-state":      `{"status": "success"}`,
 		"Cisco-IOS-XE-wireless-access-point-cfg-rpc:set-ap-slot-admin-state": `{"status": "success"}`,
 		"Cisco-IOS-XE-wireless-access-point-cmd-rpc:ap-reset":                `{"status": "success"}`,
-		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tag=aa:bb:cc:dd:ee:ff":  `{"status": "success"}`,
+		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:ff": `{
+			"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
+				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"site-tag": "existing-site",
+				"policy-tag": "existing-policy",
+				"rf-tag": "existing-rf"
+			}]
+		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [{
 				"wtp-mac": "aa:bb:cc:dd:ee:ff",
@@ -2124,7 +2131,7 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 			},
 		),
 		testutil.WithCustomResponse(
-			"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tag=aa:bb:cc:dd:ee:ff", testutil.ResponseConfig{
+			"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:ff", testutil.ResponseConfig{
 				StatusCode: 400,
 				Body:       "Invalid request",
 			},

--- a/service/rf/cfg.go
+++ b/service/rf/cfg.go
@@ -85,12 +85,12 @@ type AtfPolicyDetail struct {
 
 // RFTag represents RF tag configuration.
 type RFTag struct {
-	TagName             string             `json:"tag-name"`                          // RF tag name identifier (Live: IOS-XE 17.12.6a)
-	Description         string             `json:"description,omitempty"`             // RF tag description (Live: IOS-XE 17.12.6a)
-	Dot11ARfProfileName string             `json:"dot11a-rf-profile-name,omitempty"`  // 802.11a RF profile name (Live: IOS-XE 17.12.6a)
-	Dot11BRfProfileName string             `json:"dot11b-rf-profile-name,omitempty"`  // 802.11b RF profile name (Live: IOS-XE 17.12.6a)
-	Dot116GhzRFProfName string             `json:"dot11-6ghz-rf-prof-name,omitempty"` // 802.11 6GHz RF profile name (Live: IOS-XE 17.12.6a)
-	RFTagRadioProfiles  RFTagRadioProfiles `json:"rf-tag-radio-profiles"`             // RF tag radio profiles data (Live: IOS-XE 17.12.6a)
+	TagName             string              `json:"tag-name"`                          // RF tag name identifier (Live: IOS-XE 17.12.6a)
+	Description         string              `json:"description,omitempty"`             // RF tag description (Live: IOS-XE 17.12.6a)
+	Dot11ARfProfileName string              `json:"dot11a-rf-profile-name,omitempty"`  // 802.11a RF profile name (Live: IOS-XE 17.12.6a)
+	Dot11BRfProfileName string              `json:"dot11b-rf-profile-name,omitempty"`  // 802.11b RF profile name (Live: IOS-XE 17.12.6a)
+	Dot116GhzRFProfName string              `json:"dot11-6ghz-rf-prof-name,omitempty"` // 802.11 6GHz RF profile name (Live: IOS-XE 17.12.6a)
+	RFTagRadioProfiles  *RFTagRadioProfiles `json:"rf-tag-radio-profiles,omitempty"`   // RF tag radio profiles data (Live: IOS-XE 17.12.6a)
 }
 
 // RFTagRadioProfiles represents RF tag radio profiles collection.

--- a/service/rf/cfg.go
+++ b/service/rf/cfg.go
@@ -95,7 +95,7 @@ type RFTag struct {
 
 // RFTagRadioProfiles represents RF tag radio profiles collection.
 type RFTagRadioProfiles struct {
-	RFTagRadioProfile []RFTagRadioProfile `json:"rf-tag-radio-profile"` // Slot specific radio profile list (Live: IOS-XE 17.12.6a)
+	RFTagRadioProfile []RFTagRadioProfile `json:"rf-tag-radio-profile,omitempty"` // Slot specific radio profile list (Live: IOS-XE 17.12.6a)
 }
 
 // RFTagRadioProfile represents RF tag radio profile configuration.

--- a/tests/scenario/rf/tag_service_test.go
+++ b/tests/scenario/rf/tag_service_test.go
@@ -53,7 +53,7 @@ func executeStandardRFTagWorkflow(t *testing.T, tsc *scenario.TagContext, servic
 	if err := service.CreateRFTag(tsc.Ctx, &rf.RFTag{
 		TagName:     tsc.TestTagName,
 		Description: expectedRFTagDescription,
-		RFTagRadioProfiles: rf.RFTagRadioProfiles{
+		RFTagRadioProfiles: &rf.RFTagRadioProfiles{
 			RFTagRadioProfile: []rf.RFTagRadioProfile{
 				{
 					SlotID: "slot-0",


### PR DESCRIPTION
## 📌 WHAT

This PR repairs the AP and RF tag write paths, neither of which could succeed against a controller, and stops the AP one from replacing configuration the caller never named. It orders the commits so the read-modify-write lands before the path correction that would otherwise arm that replace, because the failing path is the only thing holding it back today.

> [!IMPORTANT]
> **BREAKING CHANGE**
>
> - `rf.RFTag.RFTagRadioProfiles` is now `*RFTagRadioProfiles` — a caller building the struct takes the address of the container.
> - `AssignSiteTag`, `AssignPolicyTag` and `AssignRFTag` reach the controller for the first time, so a caller that relied on them erroring now performs a real edit.
> - `CreateRFTag` and the RF tag setters now succeed where they returned an error, so a caller treating that error as a no-op sees a behavior change.
> - Every tag assignment issues a read before its write, so a test that mocks only the write path sees an extra request.

## ✨ KEY CHANGES

This PR repairs two write paths, **each of which replaced state the caller never named**, and sequences the changes so no intermediate commit is more dangerous than the current release.

- **Merge**: Read the AP's current tag entry and carry over what the caller did not name, routing an omitted tag back through the defaults rather than writing an empty leaf.
- **Path**: Send the write to the node the read path and the decode types already use, replacing one the controller does not serve.
- **Priming**: Declare the priming profile leaf the write body was missing against its own read type, so a replace no longer deletes an assignment.
- **RF**: Make the radio-profile container a pointer and its list omittable, so a payload no longer carries a null list the controller rejects.

> [!NOTE]
> The order is the substance of this PR, not its packaging. The first commit is safe alone because the write still fails, and the second is safe only because the first precedes it.

<details>
<summary>Click to show full commits</summary>

**Merge**

- 🐛 [fix(service): preserve the AP tags an assign omits](https://github.com/umatare5/cisco-ios-xe-wireless-go/commit/8ed5bdd68525f3a8f00b5a39100262034f0b98ef)

**Path**

- 🐛 [fix(service): send AP tag writes to ap-tags/ap-tag](https://github.com/umatare5/cisco-ios-xe-wireless-go/commit/7dad0f01776e2e2f99371b57bb7f5a599eafbbe9)

**Priming**

- 🐛 [fix(service): keep an AP priming profile across a tag write](https://github.com/umatare5/cisco-ios-xe-wireless-go/commit/082b51f667e4869a2248f491bed7fe1f584f3385)

**RF**

- 🐛 [fix(service)!: make RF tag radio profiles optional](https://github.com/umatare5/cisco-ios-xe-wireless-go/commit/9a5d9f2ccb315f31f6bdae5aa00038e17268d24b)
- 🐛 [fix(service): omit an empty RF tag radio profile list](https://github.com/umatare5/cisco-ios-xe-wireless-go/commit/1eac2f23b7f5c755ffc7d51fde3223f42d3cb846)

</details>

## ✅ TESTING

- **Automated**: `go build`, `go vet` under every build tag, and `go test ./...` with and without `-race` all pass — 42 packages, no failures, on every commit of the series.
- **Lint**: `golangci-lint run` reports zero findings, `go mod tidy` leaves no diff, and the formatter asks for no file this branch touches.
- **Mutation**: Four mutations — a merge that ignores its read, a carried value that skips the defaults, a reverted path, and a dropped priming carry-through — each fail a named test, with a build gate so a mutation that does not compile cannot read as a survivor.
- **Controller**: Each fix was exercised against a real controller through the typed API, and the read-back confirms the tags and the priming profile the caller did not name survived the write.
- **Consumer**: A dependent module builds, vets and tests green against this branch with its own sources unchanged.

## 🧭 REVIEW GUIDE

1. **Order**: Read the commits in sequence and confirm no tree state carries the path correction without the merge ahead of it.
2. **Merge**: `service/ap/service.go` holds `resolveAPTagData`, which reads the entry and decides what the write may omit.
3. **Payload**: `service/ap/rpc_payload.go` gains the one leaf the write body did not declare against the read type it merges from.
4. **RF**: `service/rf/cfg.go` carries both halves of the container fix, matching the shape the policy and site tag types already declare.
5. **Tests**: `service/ap/service_test.go` records the request body, so read the assertions rather than the mock paths.

> [!TIP]
> The path correction is the dangerous commit in isolation. Before this branch the write reached a node the controller does not serve, so approving it without the merge ahead of it converts three always-failing methods into three that silently replace an AP's other tags.

## 📋 NOTES

- **Scope**: `APTagPath` stays in the routes package — nothing references it, and removing a dead constant belongs to its own pass.
- **Verification**: The controller checks ran against a single controller, so nothing here is claimed to hold across releases.

## CHECKS

- [ ] Require Integration Test Support <!-- maintainers will perform integration test and coverage analysis. -->
