### PR TITLE
Expect 404 on the two presence-container integration reads

### DIFF
--- a/tests/integration/ap_service_test.go
+++ b/tests/integration/ap_service_test.go
@@ -425,7 +425,8 @@ func TestAPServiceIntegration_GlobalOperations_Success(t *testing.T) {
 				Method: func(ctx context.Context, service any) (any, error) {
 					return service.(ap.Service).ListEwlcMewlcPredownloadRec(ctx)
 				},
-				LogResult: true,
+				LogResult:      true,
+				ExpectNotFound: true, // Presence container: answered on 17.12, 404 from 17.15 on
 			},
 			{
 				Name: "ListApNhGlobalData",

--- a/tests/integration/awips_service_test.go
+++ b/tests/integration/awips_service_test.go
@@ -45,7 +45,8 @@ func TestAWIPSServiceIntegration_GetOperationalOperations_Success(t *testing.T) 
 				Method: func(ctx context.Context, service any) (any, error) {
 					return service.(awips.Service).ListAWIPSDwldStatus(ctx)
 				},
-				LogResult: true,
+				LogResult:      true,
+				ExpectNotFound: true, // Presence container: answered on 17.12, 404 from 17.15 on
 			},
 			{
 				Name: "ListAWIPSApDwldStatus",


### PR DESCRIPTION
## WHAT

SSIA.

- [test(integration): expect 404 on two presence containers](https://github.com/umatare5/cisco-ios-xe-wireless-go/commit/5fcb42f)

Upstream: https://github.com/umatare5/cisco-ios-xe-wireless-go/pull/74

## NOTES

- **Reason**: Both nodes are YANG presence containers, so RESTCONF answers 404 until something instantiates them — the harness field records that rather than masking a regression.
- **Scope**: Neither accessor is removed. Both answer 200 on 17.12, which this SDK still targets, and the served modules declare both on 17.12, 17.15, 17.18 and 26.01 with no status statement.

## CHECKS

- [ ] Require Integration Test Support <!-- maintainers will perform integration test and coverage analysis. -->
