### PR TITLE
ci: gate commits with the pre-commit framework

### DIFF
--- a/.githooks/no-commit-to-main
+++ b/.githooks/no-commit-to-main
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #
-# Pre-commit gate. A secret is the only finding a later gate cannot undo, so that is what runs
-# here; format and lint belong to CI, which pins its own golangci-lint version.
+# Branch guard. Secrets, format and lint are hooks of their own in .pre-commit-config.yaml;
+# this one only keeps main free of direct commits.
 #
 
 set -euo pipefail
 
 die() {
-    printf 'pre-commit: %s\n' "$*" >&2
+    printf 'no-commit-to-main: %s\n' "$*" >&2
     exit 1
 }
 
@@ -38,14 +38,4 @@ assert_branch() {
     [[ "${branch}" != 'main' ]] || die 'main takes merges only - commit to a branch'
 }
 
-# The only check here that reads the index rather than the working tree.
-check_secrets() {
-    gitleaks git --staged --no-banner --redact=100
-}
-
-main() {
-    assert_branch
-    check_secrets
-}
-
-main "$@"
+assert_branch

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,36 @@
+# gitleaks configuration file
+# More information: https://github.com/gitleaks/gitleaks#configuration
+
+# Without this the default ruleset is replaced rather than extended, and nothing is detected.
+[extend]
+useDefault = true
+
+# WNC_ACCESS_TOKEN is base64 of "username:password", so every documented example reads as a
+# generic API key. Each block below pairs one placeholder with the files it belongs in, under
+# condition = "AND": the value is allowed there and nowhere else, so the same string committed
+# to a new file is still reported. Findings that survive only in history are pinned by
+# fingerprint in .gitleaksignore instead, which cannot mask a future commit.
+
+[[allowlists]]
+description = "admin:your-password, the README quick-start example"
+condition = "AND"
+paths = ['''^README\.md$''']
+regexes = ['''^YWRtaW46eW91ci1wYXNzd29yZA==$''']
+
+[[allowlists]]
+description = "admin:your-secure-password, the credential-handling example"
+condition = "AND"
+paths = ['''^docs/SECURITY\.md$''']
+regexes = ['''^YWRtaW46eW91ci1zZWN1cmUtcGFzc3dvcmQ=$''']
+
+[[allowlists]]
+description = "admin:password, the test-setup example"
+condition = "AND"
+paths = ['''^docs/TESTING\.md$''', '''^wnc_test\.go$''']
+regexes = ['''^YWRtaW46cGFzc3dvcmQ=$''']
+
+[[allowlists]]
+description = "test:test, the unit-test fixture token"
+condition = "AND"
+paths = ['''^internal/core/client_test\.go$''', '''^wnc_test\.go$''']
+regexes = ['''^dGVzdDp0ZXN0$''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,10 @@
+# Fingerprints of findings that survive only in history. Format is
+# <commit>:<file>:<rule>:<line>, so an entry is pinned to one commit and cannot silence the
+# same value in a later one. Live placeholders are scoped by path in .gitleaks.toml instead.
+#
+# Every value below is a WNC_ACCESS_TOKEN documentation example or a test fixture.
+84df69e7d9beb81a513042df3d61c88294f46bc6:scripts/get_yang_model_details.sh:generic-api-key:80
+84df69e7d9beb81a513042df3d61c88294f46bc6:scripts/get_yang_statement_details.sh:generic-api-key:78
+84df69e7d9beb81a513042df3d61c88294f46bc6:scripts/list_yang_models.sh:generic-api-key:51
+f6921e398189cf6547f646b3caa8f38dfd3b6841:docs/SECURITY.md:generic-api-key:13
+fb8dff9d31669e9acd08b23b268d191a2859808d:internal/validation/validation_test.go:generic-api-key:73

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.13.1
+    hooks:
+      - id: golangci-lint-full
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks-system
+        # The upstream hook definition omits this, and gitleaks takes a lone
+        # positional argument as the repository path
+        pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: no-commit-to-main
+        name: no-commit-to-main
+        entry: .githooks/no-commit-to-main
+        language: script
+        pass_filenames: false
+        always_run: true
+
+      - id: markdownlint-cli2
+        name: markdownlint-cli2
+        entry: markdownlint-cli2 --fix
+        language: system
+        types: [markdown]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ make deps                # Install build and test dependencies
 make pre-commit-install  # Set up pre-commit hooks for code quality
 ```
 
+`make deps` installs Go tooling only, so install [pre-commit](https://pre-commit.com/#install) yourself first. `make pre-commit-install` then registers the hooks declared in [.pre-commit-config.yaml](./.pre-commit-config.yaml).
+
+Every commit is gated on `golangci-lint`, `gitleaks`, `markdownlint-cli2` and a guard that keeps `main` free of direct commits. Run `make pre-commit-test` to check the whole tree without committing.
+
 ### Quick Build & Tests
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,16 @@ build:
 	@go build ./...
 
 # Pre-commit Hook Management
-# Install pre-commit hook to prevent direct commits to main branch
+# Install the pre-commit hooks declared in .pre-commit-config.yaml
 pre-commit-install:
-	@ln -sf ../../.githooks/pre-commit .git/hooks/pre-commit
-	@echo "✓ Pre-commit hook installed"
+	@command -v pre-commit >/dev/null 2>&1 || \
+		{ echo "✗ pre-commit not found - see https://pre-commit.com/#install"; exit 1; }
+	@pre-commit install --allow-missing-config
 
-# Test pre-commit hook without installing
+# Run every hook across the whole tree without committing
 pre-commit-test:
-	@./.githooks/pre-commit
+	@pre-commit run --all-files
 
 # Uninstall pre-commit hook
 pre-commit-uninstall:
-	@rm -f .git/hooks/pre-commit
-	@echo "✓ Pre-commit hook uninstalled"
+	@pre-commit uninstall

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "dependencyDashboard": false
+  "dependencyDashboard": false,
+  "pre-commit": { "enabled": true }
 }


### PR DESCRIPTION
## WHAT

Move the commit-time gate from the hand-rolled `.githooks/pre-commit` to the [pre-commit](https://pre-commit.com) framework.

- **`.pre-commit-config.yaml`** — four hooks: `golangci-lint-full` (pinned `v2.13.1`), `gitleaks-system` (pinned `v8.30.1`), the `main` branch guard, and `markdownlint-cli2`.
- **`.githooks/no-commit-to-main`** — renamed from `.githooks/pre-commit` and reduced to the branch guard alone; secrets now belong to the `gitleaks` hook. The sequencer bypass for merge, rebase and cherry-pick is unchanged.
- **`.gitleaks.toml` / `.gitleaksignore`** — the `WNC_ACCESS_TOKEN` examples already committed in docs and tests read as generic API keys and would otherwise block every edit to those files.
- **`Makefile`** — `pre-commit-install`, `pre-commit-test` and `pre-commit-uninstall` keep their names and now drive the framework. `pre-commit-test` runs every hook across the tree.
- **`renovate.json`** — enables the `pre-commit` manager so the pinned hook revisions stay current.

## WHY

`make lint` was the only practical gate, and it is opt-in. The old hook deliberately ran secrets only, on the grounds that CI pins its own `golangci-lint` version and the hook should keep no second copy; `rev: v2.13.1` in `.pre-commit-config.yaml` pins it the same way, so lint can move to commit time without that duplication.

CI is unchanged — `go-test-fmt.yml` and `actionlint.yml` still run the same checks.

### On the gitleaks exemptions

Two mechanisms, because the risk differs:

- **`.gitleaks.toml`** pairs each live placeholder with the paths it belongs in, under `condition = "AND"`. The value is allowed there and nowhere else, so the same string committed to a new file is still reported. A value-only allowlist would have exempted these strings from every future commit.
- **`.gitleaksignore`** pins findings that survive only in history by `<commit>:<file>:<rule>:<line>`. An entry is bound to one commit and cannot mask a later one.

Every exempted value is a documentation example or a test fixture; none is a live credential, and none survives in the working tree beyond the paths named above.

## CHECKS

- [ ] Require Integration Test Support