### PR TITLE
Unify test fixture identities and remove captured lab data

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,32 +5,12 @@
 [extend]
 useDefault = true
 
-# WNC_ACCESS_TOKEN is base64 of "username:password", so every documented example reads as a
-# generic API key. Each block below pairs one placeholder with the files it belongs in, under
-# condition = "AND": the value is allowed there and nowhere else, so the same string committed
-# to a new file is still reported. Findings that survive only in history are pinned by
-# fingerprint in .gitleaksignore instead, which cannot mask a future commit.
-
-[[allowlists]]
-description = "admin:your-password, the README quick-start example"
-condition = "AND"
-paths = ['''^README\.md$''']
-regexes = ['''^YWRtaW46eW91ci1wYXNzd29yZA==$''']
-
-[[allowlists]]
-description = "admin:your-secure-password, the credential-handling example"
-condition = "AND"
-paths = ['''^docs/SECURITY\.md$''']
-regexes = ['''^YWRtaW46eW91ci1zZWN1cmUtcGFzc3dvcmQ=$''']
-
-[[allowlists]]
-description = "admin:password, the test-setup example"
-condition = "AND"
-paths = ['''^docs/TESTING\.md$''', '''^wnc_test\.go$''']
-regexes = ['''^YWRtaW46cGFzc3dvcmQ=$''']
-
-[[allowlists]]
-description = "test:test, the unit-test fixture token"
-condition = "AND"
-paths = ['''^internal/core/client_test\.go$''', '''^wnc_test\.go$''']
-regexes = ['''^dGVzdDp0ZXN0$''']
+# No live allowlist. WNC_ACCESS_TOKEN is base64 of "username:password", so a documented example
+# value reads as a generic API key and used to need one exception per placeholder. The docs now
+# derive the token instead of printing it -- README.md and docs/SECURITY.md show
+# `export WNC_ACCESS_TOKEN="$(echo -n 'admin:your-password' | base64)"` -- and every fixture
+# carries the low-entropy `test-token-123`, so nothing in the tree reads as a secret.
+#
+# Keep it that way: a base64 literal added back here would need an allowlist entry, and an entry
+# scoped to a path silences that value for every future commit to it. Findings that survive only
+# in history are pinned by fingerprint in .gitleaksignore, which cannot mask a future commit.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,10 +1,26 @@
 # Fingerprints of findings that survive only in history. Format is
 # <commit>:<file>:<rule>:<line>, so an entry is pinned to one commit and cannot silence the
-# same value in a later one. Live placeholders are scoped by path in .gitleaks.toml instead.
+# same value in a later one. Nothing in the tree needs a live exception, so .gitleaks.toml
+# carries no allowlist -- see the note there before adding one.
 #
-# Every value below is a WNC_ACCESS_TOKEN documentation example or a test fixture.
+# Every entry is a WNC_ACCESS_TOKEN example, which is base64 of "username:password". The heading
+# above each group is what that group's value decodes to. A comment has to stand on its own line:
+# gitleaks reads the whole line as the fingerprint, so a trailing "# ..." breaks the match and
+# the finding comes back.
+
+# base64("user:password") -- the script usage examples
 84df69e7d9beb81a513042df3d61c88294f46bc6:scripts/get_yang_model_details.sh:generic-api-key:80
 84df69e7d9beb81a513042df3d61c88294f46bc6:scripts/get_yang_statement_details.sh:generic-api-key:78
 84df69e7d9beb81a513042df3d61c88294f46bc6:scripts/list_yang_models.sh:generic-api-key:51
+
+# base64("admin:your-password") -- the README quick-start and credential-handling examples
+3a320026f110001bb15c1db90f7ade0eaf38003a:README.md:generic-api-key:57
+3a320026f110001bb15c1db90f7ade0eaf38003a:README.md:generic-api-key:130
+5ce01b7d671fbcd33eed516feb2b43ee8ab9c858:README.md:generic-api-key:114
 f6921e398189cf6547f646b3caa8f38dfd3b6841:docs/SECURITY.md:generic-api-key:13
+
+# base64("admin:password") -- the test-setup example
+34b1ed53b46cf1901102168cb5cb0f660daf8ada:docs/TESTING.md:generic-api-key:43
+
+# base64("admin:password1234567890") -- the token-length validation case
 fb8dff9d31669e9acd08b23b268d191a2859808d:internal/validation/validation_test.go:generic-api-key:73

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ GET a single entry by list key (MAC address):
 ```bash
 curl -k -H "Authorization: Basic $WNC_ACCESS_TOKEN" \
         -H "Accept: application/yang-data+json" \
-        "https://$WNC_CONTROLLER/restconf/data/Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=00:11:22:33:44:55"
+        "https://$WNC_CONTROLLER/restconf/data/Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01"
 ```
 
 POST an RPC operation (`/restconf/operations/`):
@@ -100,7 +100,7 @@ POST an RPC operation (`/restconf/operations/`):
 curl -k -X POST \
         -H "Authorization: Basic $WNC_ACCESS_TOKEN" \
         -H "Content-Type: application/yang-data+json" \
-        -d '{"input": {"ap-name": "AP-NAME"}}' \
+        -d '{"input": {"ap-name": "TEST-AP01"}}' \
         "https://$WNC_CONTROLLER/restconf/operations/Cisco-IOS-XE-wireless-access-point-cmd-rpc:ap-reset"
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ You have to enable RESTCONF and HTTPS on the C9800 before using this SDK. Please
 Encode your controller credentials as Base64.
 
 ```bash
-# username:password → Base64
-echo -n "admin:your-password" | base64
-# Output: YWRtaW46eW91ci1wYXNzd29yZA==
+# The access token is base64("username:password")
+export WNC_ACCESS_TOKEN="$(echo -n 'admin:your-password' | base64)"
 ```
 
 ### 2. Create a sample application
@@ -118,7 +117,7 @@ func main() {
 ```bash
 # Set environment variables
 export WNC_CONTROLLER="wnc1.example.internal"
-export WNC_ACCESS_TOKEN="YWRtaW46eW91ci1wYXNzd29yZA=="
+export WNC_ACCESS_TOKEN="test-token-123"
 
 # Run the application
 go run main.go
@@ -275,8 +274,8 @@ Successfully connected! Found 2 APs
 
 AP Name           | MAC Address         | IP Address       | Status
 ------------------|---------------------|------------------|-----------------
-TEST-AP01         | aa:bb:ff:dd:ee:a0   | 192.168.255.11   | registered
-TEST-AP02         | aa:bb:ff:dd:ee:b0   | 192.168.255.12   | registered
+TEST-AP01         | aa:bb:cc:dd:ee:01   | 192.168.1.11   | registered
+TEST-AP02         | aa:bb:cc:dd:ee:02   | 192.168.1.12   | registered
 ```
 
 </p></details>
@@ -294,10 +293,10 @@ Successfully connected! Found 17 clients
 
 MAC Address           | IP Address
 ----------------------|----------------
-08:84:9d:92:47:00     | 192.168.0.84
-2a:e3:42:8f:06:c8     | 192.168.0.89
-40:23:43:3e:c5:bf     | 192.168.0.62
-40:80:e1:6b:11:16     | 192.168.0.92
+aa:bb:cc:dd:ee:a1     | 192.168.1.101
+aa:bb:cc:dd:ee:a2     | 192.168.1.102
+aa:bb:cc:dd:ee:a3     | 192.168.1.103
+aa:bb:cc:dd:ee:a4     | 192.168.1.104
 <snip>
 ```
 
@@ -316,9 +315,9 @@ Successfully connected! Found 7 WLANs across all APs
 
 AP Name           | AP MAC Address    | Slot | WLAN | BSSID             | SSID
 ------------------|-------------------|------|------|-------------------|-------------------------
-TEST-AP01         | aa:bb:ff:dd:ee:a0 |    0 |    1 | aa:bb:ff:dd:ee:a1 | labo-wlan
-TEST-AP01         | aa:bb:ff:dd:ee:a0 |    1 |    2 | aa:bb:ff:dd:ee:ad | labo-psk
-TEST-AP01         | aa:bb:ff:dd:ee:a0 |    1 |    4 | aa:bb:ff:dd:ee:af | labo-tls
+TEST-AP01         | aa:bb:cc:dd:ee:01 |    0 |    1 | aa:bb:cc:dd:ee:b1 | test-wlan
+TEST-AP01         | aa:bb:cc:dd:ee:01 |    1 |    2 | aa:bb:cc:dd:ee:b2 | test-psk
+TEST-AP01         | aa:bb:cc:dd:ee:01 |    1 |    4 | aa:bb:cc:dd:ee:b3 | test-tls
 <snip>
 ```
 
@@ -337,9 +336,9 @@ Successfully connected! Found 11 AP neighbors
 
 AP Name           | Slot | Neighbor BSSID    | Neighbor SSID          | RSSI  | Channel | Last Heard At
 ------------------|------|-------------------|------------------------|-------|---------|--------------------------
-TEST-AP01         |    0 | d8:21:da:a2:30:f0 | Rogue-WiFi             |   -20 |      11 | 2025-09-12 20:24:57
-TEST-AP01         |    0 | 08:10:86:bf:07:e3 | rogue-abcdef123-g      |   -62 |       4 | 2025-09-13 06:49:59
-TEST-AP01         |    1 | 98:f1:99:c2:03:db | rogue-abcdef123        |   -64 |      36 | 2025-09-13 06:52:57
+TEST-AP01         |    0 | aa:bb:cc:dd:ee:f1 | test-rogue-01         |   -20 |      11 | 2024-01-15 10:40:00
+TEST-AP01         |    0 | aa:bb:cc:dd:ee:f2 | test-rogue-02         |   -62 |       4 | 2024-01-15 10:41:00
+TEST-AP01         |    1 | aa:bb:cc:dd:ee:f3 | test-rogue-03         |   -64 |      36 | 2024-01-15 10:42:00
 <snip>
 ```
 
@@ -361,15 +360,15 @@ WARNING: This tool will restart access points causing service interruption!
 Use only in controlled environments with proper authorization.
 
 Target Controller: wnc1.example.internal
-Enter AP MAC address (format: xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx): aa:bb:ff:dd:ee:a0
-Target AP MAC: aa:bb:ff:dd:ee:a0
+Enter AP MAC address (format: xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx): aa:bb:cc:dd:ee:01
+Target AP MAC: aa:bb:cc:dd:ee:01
 This will restart the specified Access Point(s). Type 'YES' to confirm: YES
 
 ✓ WNC client created successfully
-Executing AP reset for MAC aa:bb:ff:dd:ee:a0
+Executing AP reset for MAC aa:bb:cc:dd:ee:01
 WARNING: AP will become unavailable and disconnect all clients during restart...
 
-✓ AP reset command sent successfully for MAC: aa:bb:ff:dd:ee:a0
+✓ AP reset command sent successfully for MAC: aa:bb:cc:dd:ee:01
 Note: AP is now restarting and will be temporarily unavailable
 Clients will need to reconnect after AP restart completes
 ```
@@ -394,7 +393,7 @@ Target Controller: wnc1.example.internal
 This will restart the WNC controller. Type 'YES' to confirm: YES
 
 ✓ WNC client created successfully
-Executing controller reload with reason: Manual reload via CLI tool at 2025-09-06T13:11:50+09:00
+Executing controller reload with reason: Manual reload via CLI tool at 2024-01-15T10:30:00+09:00
 WARNING: Controller will become unavailable during restart...
 
 ✓ Controller reload command sent successfully

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -75,8 +75,7 @@ Handle authentication tokens securely with isolated storage, periodic rotation, 
 
    ```bash
     # Generate token manually (ad-hoc only)
-   echo -n "admin:your-secure-password" | base64
-   # Output: YWRtaW46eW91ci1zZWN1cmUtcGFzc3dvcmQ=
+   export WNC_ACCESS_TOKEN="$(echo -n 'admin:your-secure-password' | base64)"
 
     # Prefer central secret store, not ad-hoc scripts
    ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -88,6 +88,37 @@ TestXServiceIntegration_GetConfigurationOperations_Success // Live WNC configura
 - `TestApServiceUnit_SetOperations_ValidationErrors` - AP SET validation and edge cases
 - `TestClientServiceIntegration_GetOperationalOperations_Success` - Client GET against a live controller
 
+### Fixture Identities
+
+Mock payloads take their **shape** from a real controller response, but every identity in them is
+synthetic. MAC addresses come from one locally administered block, `aa:bb:cc:dd:ee:00/40`, whose
+last octet encodes the role of the device, so a fixture reads without cross-referencing anything:
+
+| Range       | Role                                                    |
+| ----------- | ------------------------------------------------------- |
+| `:00`       | Controller management interface                         |
+| `:01`-`:0f` | AP radio base MAC — `TEST-APnn` pairs with `:nn`        |
+| `:11`-`:1f` | AP Ethernet MAC — `TEST-APnn` pairs with `:1n`          |
+| `:a1`-`:af` | Associated client stations                              |
+| `:b1`-`:bf` | BSSIDs advertised by fixture APs                        |
+| `:f1`-`:ff` | Rogue and otherwise unmanaged devices                   |
+
+The first octet `0xaa` has the I/G bit clear and the U/L bit set, so no fixture address can be a
+multicast address or collide with a real vendor assignment. The other identities follow the same
+rule: `TEST-APnn` for access points, `wnc1.example.internal` for the controller, `test-token-123`
+for the access token, `192.168.1.0/24` for addresses, and `test-` prefixed names for tags,
+profiles and SSIDs.
+
+Two categories are deliberately outside this scheme. **Format tests** — `internal/validation`,
+`internal/service/mac_test.go`, and the spelling table in `service/client` — assert how a MAC is
+parsed and normalized rather than which device it names, so they keep `00:11:22:33:44:55` and its
+hyphen, dotted and bare spellings. **Absence tests** in `service/ap` use `00:00:00:00:00:01` and
+the `-CONTROL` name suffix to mark the control group that proves a container was reached.
+
+Never paste a MAC, hostname, SSID, tag name or timestamp straight from a capture into a committed
+fixture. `tests/testutil/integration` redacts captures it writes, but a value pasted by hand
+bypasses it.
+
 ## 🧰 Prerequisites
 
 ### For Unit Tests (Layers 1-3)
@@ -107,14 +138,14 @@ Integration and E2E tests require a real Cisco Catalyst 9800 WNC. Please refer t
 
 #### 2. Environment Variables
 
-| Variable                | Description            | Example                 |
-| ----------------------- | ---------------------- | ----------------------- |
-| `WNC_CONTROLLER`        | Controller host/IP     | `wnc1.example.internal` |
-| `WNC_ACCESS_TOKEN`      | Base64 `user:pass`     | `YWRtaW46cGFzc3dvcmQ=`  |
-| `WNC_AP_MAC_ADDR`       | Test AP's Radio MAC    | `aa:bb:cc:dd:ee:f0`     |
-| `WNC_CLIENT_MAC_ADDR`   | Test Client MAC        | `11:22:33:aa:bb:cc`     |
-| `WNC_AP_WLAN_BSSID`     | Test AP WLAN BSSID     | `aa:bb:cc:dd:ee:f1`     |
-| `WNC_AP_NEIGHBOR_BSSID` | Test AP Neighbor BSSID | `11:22:33:dd:ee:ff`     |
+| Variable                | Description            | Example                             |
+| ----------------------- | ---------------------- | ----------------------------------- |
+| `WNC_CONTROLLER`        | Controller host/IP     | `wnc1.example.internal`             |
+| `WNC_ACCESS_TOKEN`      | Base64 `user:pass`     | `$(echo -n 'admin:pass' \| base64)` |
+| `WNC_AP_MAC_ADDR`       | Test AP's Radio MAC    | `aa:bb:cc:dd:ee:01`                 |
+| `WNC_CLIENT_MAC_ADDR`   | Test Client MAC        | `aa:bb:cc:dd:ee:a1`                 |
+| `WNC_AP_WLAN_BSSID`     | Test AP WLAN BSSID     | `aa:bb:cc:dd:ee:b1`                 |
+| `WNC_AP_NEIGHBOR_BSSID` | Test AP Neighbor BSSID | `aa:bb:cc:dd:ee:b2`                 |
 
 <details><summary>Environment setup</summary>
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -107,7 +107,9 @@ The first octet `0xaa` has the I/G bit clear and the U/L bit set, so no fixture 
 multicast address or collide with a real vendor assignment. The other identities follow the same
 rule: `TEST-APnn` for access points, `wnc1.example.internal` for the controller, `test-token-123`
 for the access token, `192.168.1.0/24` for addresses, and `test-` prefixed names for tags,
-profiles and SSIDs.
+profiles and SSIDs. A serial number cannot take that prefix and keep its shape, so it reads
+`TST0000APnn` — a valid `[A-Z]{3}[0-9]{4}[A-Z0-9]{4}` that no site code and no week 00 of year
+00 can collide with.
 
 Two categories are deliberately outside this scheme. **Format tests** — `internal/validation`,
 `internal/service/mac_test.go`, and the spelling table in `service/client` — assert how a MAC is
@@ -115,9 +117,10 @@ parsed and normalized rather than which device it names, so they keep `00:11:22:
 hyphen, dotted and bare spellings. **Absence tests** in `service/ap` use `00:00:00:00:00:01` and
 the `-CONTROL` name suffix to mark the control group that proves a container was reached.
 
-Never paste a MAC, hostname, SSID, tag name or timestamp straight from a capture into a committed
-fixture. `tests/testutil/integration` redacts captures it writes, but a value pasted by hand
-bypasses it.
+Never paste a MAC, serial number, hostname, SSID, tag name or timestamp straight from a capture
+into a committed fixture. `tests/testutil/integration` redacts every one of those in the captures
+it writes -- `captureSerial` alone matches the shape a Cisco serial takes -- but a value pasted by
+hand reaches the tree without passing through it.
 
 ## 🧰 Prerequisites
 

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -32,8 +32,8 @@ const (
 
 // TestCoreClientUnit_Constructor_Success tests the new core client creation.
 func TestCoreClientUnit_Constructor_Success(t *testing.T) {
-	controller := "test.example.com"
-	token := "dGVzdDp0ZXN0"
+	controller := "wnc1.example.internal"
+	token := "test-token-123"
 
 	t.Run("ValidClient", func(t *testing.T) {
 		client, err := New(controller, token)
@@ -53,8 +53,8 @@ func TestCoreClientUnit_Constructor_Success(t *testing.T) {
 
 // TestCoreClientUnit_Options_Success tests functional options.
 func TestCoreClientUnit_Options_Success(t *testing.T) {
-	controller := "test.example.com"
-	token := "dGVzdDp0ZXN0"
+	controller := "wnc1.example.internal"
+	token := "test-token-123"
 
 	t.Run("WithTimeout", func(t *testing.T) {
 		client, err := New(controller, token, WithTimeout(testTimeout))
@@ -79,8 +79,8 @@ func TestCoreClientUnit_Options_Success(t *testing.T) {
 
 // TestCoreClientUnit_WithProxy_Success tests the proxy resolver option.
 func TestCoreClientUnit_WithProxy_Success(t *testing.T) {
-	controller := "test.example.com"
-	token := "dGVzdDp0ZXN0"
+	controller := "wnc1.example.internal"
+	token := "test-token-123"
 
 	t.Run("DefaultLeavesProxyUnset", func(t *testing.T) {
 		client, err := New(controller, token)
@@ -149,7 +149,7 @@ func TestCoreClientUnit_DoOperations_Success(t *testing.T) {
 
 	// Create client with mock server
 	serverURL := strings.TrimPrefix(mockServer.URL, "https://")
-	client, err := New(serverURL, "test-token", WithInsecureSkipVerify(true), WithTimeout(testTimeout))
+	client, err := New(serverURL, "test-token-123", WithInsecureSkipVerify(true), WithTimeout(testTimeout))
 	testutil.AssertNoError(t, err, "Failed to create client")
 
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
@@ -331,7 +331,7 @@ func TestCoreClientUnit_PostOperations_Success(t *testing.T) {
 	})
 
 	t.Run("Post_marshal_error", func(t *testing.T) {
-		client, err := New("test.example.com", "test-token")
+		client, err := New("wnc1.example.internal", "test-token-123")
 		testutil.AssertClientCreated(t, client, err, "Failed to create client")
 
 		// Use a payload that cannot be marshaled to JSON
@@ -341,7 +341,7 @@ func TestCoreClientUnit_PostOperations_Success(t *testing.T) {
 	})
 
 	t.Run("Post_context_canceled", func(t *testing.T) {
-		client, err := New("test.example.com", "test-token")
+		client, err := New("wnc1.example.internal", "test-token-123")
 		testutil.AssertClientCreated(t, client, err, "Failed to create client")
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -371,7 +371,7 @@ func TestCoreClientUnit_RPCOperations_WithPayload(t *testing.T) {
 
 	// Create test client
 	serverURL := strings.TrimPrefix(server.URL, "http://")
-	testClient, err := New(serverURL, "test-token", WithInsecureSkipVerify(true))
+	testClient, err := New(serverURL, "test-token-123", WithInsecureSkipVerify(true))
 	testutil.AssertClientCreated(t, testClient, err, "Failed to create test client")
 
 	ctx := context.Background()
@@ -405,8 +405,8 @@ func TestCoreClientUnit_RPCOperations_WithPayload(t *testing.T) {
 // TestCoreClientUnit_RESTCONFBuilder tests RESTCONFBuilder method.
 func TestCoreClientUnit_RESTCONFBuilder(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		controller := "test.example.com"
-		token := "test-token"
+		controller := "wnc1.example.internal"
+		token := "test-token-123"
 		client, err := New(controller, token)
 
 		testutil.AssertNoError(t, err, "Client creation should succeed")
@@ -432,7 +432,7 @@ func TestCoreClientUnit_doWithPayload(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	client, err := New(strings.TrimPrefix(mockServer.URL, "https://"), "test-token", WithInsecureSkipVerify(true))
+	client, err := New(strings.TrimPrefix(mockServer.URL, "https://"), "test-token-123", WithInsecureSkipVerify(true))
 	testutil.AssertNoError(t, err, "Client creation should succeed")
 
 	ctx := context.Background()
@@ -453,7 +453,7 @@ func TestCoreClientUnit_GenericRequests(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	client, err := New(strings.TrimPrefix(mockServer.URL, "https://"), "test-token", WithInsecureSkipVerify(true))
+	client, err := New(strings.TrimPrefix(mockServer.URL, "https://"), "test-token-123", WithInsecureSkipVerify(true))
 	testutil.AssertNoError(t, err, "Client creation should succeed")
 
 	ctx := context.Background()
@@ -513,7 +513,7 @@ func TestCoreClientUnit_VoidRequests(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	client, err := New(strings.TrimPrefix(mockServer.URL, "https://"), "test-token", WithInsecureSkipVerify(true))
+	client, err := New(strings.TrimPrefix(mockServer.URL, "https://"), "test-token-123", WithInsecureSkipVerify(true))
 	testutil.AssertNoError(t, err, "Client creation should succeed")
 
 	ctx := context.Background()
@@ -554,8 +554,8 @@ func TestAPIErrorMethod(t *testing.T) {
 // TestCoreClientUnit_TransportOptions_Success pins the transport-level options against
 // the option-order dependency the wholesale Transport replacement created.
 func TestCoreClientUnit_TransportOptions_Success(t *testing.T) {
-	controller := "test.example.com"
-	token := "dGVzdDp0ZXN0"
+	controller := "wnc1.example.internal"
+	token := "test-token-123"
 
 	t.Run("SurvivesLaterInsecureSkipVerify", func(t *testing.T) {
 		client, err := New(controller, token,
@@ -590,7 +590,7 @@ func TestCoreClientUnit_TransportOptions_Success(t *testing.T) {
 func TestCoreClientUnit_UserAgentReachesRequest_Success(t *testing.T) {
 	const path = "Cisco-IOS-XE-wireless-general-oper:general-oper-data"
 
-	client, err := New("test.example.com", "dGVzdDp0ZXN0", WithUserAgent("  probe-agent/9.9  "))
+	client, err := New("wnc1.example.internal", "test-token-123", WithUserAgent("  probe-agent/9.9  "))
 	testutil.AssertClientCreated(t, client, err, "WithUserAgent")
 
 	req, err := client.requestBuilder.CreateRequest(context.Background(), http.MethodGet, path)
@@ -609,7 +609,7 @@ func TestCoreClientUnit_HeaderTimeout_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := New(strings.TrimPrefix(server.URL, "https://"), "dGVzdDp0ZXN0",
+	client, err := New(strings.TrimPrefix(server.URL, "https://"), "test-token-123",
 		WithInsecureSkipVerify(true), WithResponseHeaderTimeout(20*time.Millisecond))
 	testutil.AssertClientCreated(t, client, err, "HeaderTimeoutClient")
 
@@ -630,7 +630,7 @@ func TestCoreClientUnit_ConstructionInputNormalization_Success(t *testing.T) {
 	defer server.Close()
 
 	host := strings.TrimPrefix(server.URL, "https://")
-	client, err := New(" "+host+"\n", "dGVzdDp0ZXN0\n", WithInsecureSkipVerify(true))
+	client, err := New(" "+host+"\n", "test-token-123\n", WithInsecureSkipVerify(true))
 	testutil.AssertClientCreated(t, client, err, "padded host and newline-terminated token")
 
 	_, err = client.do(context.Background(), http.MethodGet, path)
@@ -649,7 +649,7 @@ func TestCoreClientUnit_ErrorBodyTruncation_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := New(strings.TrimPrefix(server.URL, "https://"), "dGVzdDp0ZXN0",
+	client, err := New(strings.TrimPrefix(server.URL, "https://"), "test-token-123",
 		WithInsecureSkipVerify(true))
 	testutil.AssertClientCreated(t, client, err, "ErrorBodyTruncation")
 
@@ -687,7 +687,7 @@ func TestCoreClientUnit_ErrorBodyTruncationBoundary_Error(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client, err := New(strings.TrimPrefix(server.URL, "https://"), "dGVzdDp0ZXN0",
+			client, err := New(strings.TrimPrefix(server.URL, "https://"), "test-token-123",
 				WithInsecureSkipVerify(true))
 			testutil.AssertClientCreated(t, client, err, "ErrorBodyTruncationBoundary")
 
@@ -720,7 +720,7 @@ func TestCoreClientUnit_ErrorBodyTruncationUTF8_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := New(strings.TrimPrefix(server.URL, "https://"), "dGVzdDp0ZXN0",
+	client, err := New(strings.TrimPrefix(server.URL, "https://"), "test-token-123",
 		WithInsecureSkipVerify(true))
 	testutil.AssertClientCreated(t, client, err, "ErrorBodyTruncationUTF8")
 
@@ -741,7 +741,7 @@ func TestCoreClientUnit_TransportErrorClassification_Error(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := New(strings.TrimPrefix(server.URL, "https://"), "dGVzdDp0ZXN0",
+		client, err := New(strings.TrimPrefix(server.URL, "https://"), "test-token-123",
 			WithInsecureSkipVerify(true))
 		testutil.AssertClientCreated(t, client, err, "CanceledIsNotTimeout")
 
@@ -764,7 +764,7 @@ func TestCoreClientUnit_TransportErrorClassification_Error(t *testing.T) {
 		addr := listener.Addr().String()
 		testutil.AssertNoError(t, listener.Close(), "close listener")
 
-		client, err := New(addr, "dGVzdDp0ZXN0", WithInsecureSkipVerify(true))
+		client, err := New(addr, "test-token-123", WithInsecureSkipVerify(true))
 		testutil.AssertClientCreated(t, client, err, "RefusedIsNotTimeout")
 
 		_, err = client.do(context.Background(), http.MethodGet,
@@ -786,7 +786,7 @@ func TestCoreClientUnit_TransportErrorClassification_Error(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client, err := New(strings.TrimPrefix(server.URL, "https://"), "dGVzdDp0ZXN0",
+		client, err := New(strings.TrimPrefix(server.URL, "https://"), "test-token-123",
 			WithInsecureSkipVerify(true), WithTimeout(300*time.Millisecond))
 		testutil.AssertClientCreated(t, client, err, "BodyReadTimeout")
 
@@ -806,10 +806,10 @@ func TestCoreClientUnit_ConstructionSentinel_Error(t *testing.T) {
 		host, token string
 		opts        []Option
 	}{
-		"malformed authority": {host: "https://wnc.example.internal", token: "test-token-123"},
+		"malformed authority": {host: "https://wnc1.example.internal", token: "test-token-123"},
 		"empty host":          {host: "   ", token: "test-token-123"},
-		"empty token":         {host: "wnc.example.internal", token: "   "},
-		"option refused":      {host: "wnc.example.internal", token: "test-token-123", opts: []Option{WithTimeout(0)}},
+		"empty token":         {host: "wnc1.example.internal", token: "   "},
+		"option refused":      {host: "wnc1.example.internal", token: "test-token-123", opts: []Option{WithTimeout(0)}},
 	}
 
 	for name, tc := range cases {
@@ -830,7 +830,7 @@ func TestCoreClientUnit_ConstructionSentinel_Error(t *testing.T) {
 // The second subtest is the assertion the doc comments rest on: bundling the three into
 // WithTimeout would pass every other test in this package and fail here.
 func TestCoreClientUnit_DefaultBudgets_Success(t *testing.T) {
-	controller := "test.example.com"
+	controller := "wnc1.example.internal"
 	token := "test-token-123"
 
 	t.Run("ConstantsNameWhatTheTransportCarries", func(t *testing.T) {

--- a/internal/core/envelope_test.go
+++ b/internal/core/envelope_test.go
@@ -26,7 +26,7 @@ func TestCoreEnvelopeUnit_NodeName_Success(t *testing.T) {
 		},
 		{
 			name:     "list key holds colons",
-			endpoint: base + "=aa:bb:cc:dd:ee:ff",
+			endpoint: base + "=aa:bb:cc:dd:ee:01",
 			expected: "common-oper-data",
 		},
 		{
@@ -36,12 +36,12 @@ func TestCoreEnvelopeUnit_NodeName_Success(t *testing.T) {
 		},
 		{
 			name:     "composite list key",
-			endpoint: base + "=aa:bb:cc:dd:ee:ff,1",
+			endpoint: base + "=aa:bb:cc:dd:ee:01,1",
 			expected: "common-oper-data",
 		},
 		{
 			name:     "query follows the list key",
-			endpoint: base + "=aa:bb:cc:dd:ee:ff?with-defaults=report-all",
+			endpoint: base + "=aa:bb:cc:dd:ee:01?with-defaults=report-all",
 			expected: "common-oper-data",
 		},
 		{
@@ -67,9 +67,9 @@ func TestCoreEnvelopeUnit_DecodeSoleKey_Success(t *testing.T) {
 		} `json:"Cisco-IOS-XE-wireless-client-oper:common-oper-data"`
 	}
 
-	body := []byte(`{"Cisco-IOS-XE-wireless-client-oper:common-oper-data":[{"client-mac":"aa:bb:cc:dd:ee:ff"}]}`)
+	body := []byte(`{"Cisco-IOS-XE-wireless-client-oper:common-oper-data":[{"client-mac":"aa:bb:cc:dd:ee:01"}]}`)
 
-	out, err := decodeSoleKey[response](body, endpoint+"=aa:bb:cc:dd:ee:ff")
+	out, err := decodeSoleKey[response](body, endpoint+"=aa:bb:cc:dd:ee:01")
 	testutil.AssertNoError(t, err, "decodeSoleKey() on a keyed read")
 	testutil.AssertIntEquals(t, len(out.CommonOperData), 1, "decoded record count")
 }

--- a/internal/errors/service.go
+++ b/internal/errors/service.go
@@ -116,8 +116,8 @@ func EmptyParameterError(parameter string) error {
 //
 // Example:
 //
-//	err := NotFoundError("AP", "28:ac:9e:11:48:10")
-//	// Result: "AP with 28:ac:9e:11:48:10 not found"
+//	err := NotFoundError("AP", "aa:bb:cc:dd:ee:02")
+//	// Result: "AP with aa:bb:cc:dd:ee:02 not found"
 func NotFoundError(entityType, identifier string) error {
 	return fmt.Errorf(ErrEntityNotFoundTemplate, entityType, identifier)
 }

--- a/internal/errors/service_test.go
+++ b/internal/errors/service_test.go
@@ -120,8 +120,8 @@ func TestErrorsServiceUnit_EmptyParameterError_Success(t *testing.T) {
 
 func TestErrorsServiceUnit_NotFoundError_Success(t *testing.T) {
 	t.Run("APWithMAC", func(t *testing.T) {
-		err := NotFoundError("AP", "28:ac:9e:11:48:10")
-		expected := "AP with 28:ac:9e:11:48:10 not found"
+		err := NotFoundError("AP", "aa:bb:cc:dd:ee:02")
+		expected := "AP with aa:bb:cc:dd:ee:02 not found"
 
 		testutil.AssertErrorMessage(t, err, expected, "NotFoundError should format AP with MAC message correctly")
 	})

--- a/internal/errors/templates.go
+++ b/internal/errors/templates.go
@@ -4,7 +4,7 @@ package errors
 const (
 	// ErrOperationFailedTemplate is the generic operation failure message template
 	// Usage: fmt.Sprintf(ErrOperationFailedTemplate, action, entity, entityID)
-	// Example: fmt.Sprintf(ErrOperationFailedTemplate, "get", "AP", "28:ac:9e:11:48:10")
+	// Example: fmt.Sprintf(ErrOperationFailedTemplate, "get", "AP", "aa:bb:cc:dd:ee:02")
 	//         fmt.Sprintf(ErrOperationFailedTemplate, "retrieve", "WLAN", "configuration")
 	ErrOperationFailedTemplate = "failed to %s %s %s: %w"
 
@@ -20,7 +20,7 @@ const (
 
 	// ErrEntityNotFoundTemplate is the entity not found error message template
 	// Usage: fmt.Sprintf(ErrEntityNotFoundTemplate, entityType, identifier)
-	// Example: fmt.Sprintf(ErrEntityNotFoundTemplate, "AP", "28:ac:9e:11:48:10").
+	// Example: fmt.Sprintf(ErrEntityNotFoundTemplate, "AP", "aa:bb:cc:dd:ee:02").
 	ErrEntityNotFoundTemplate = "%s with %s not found"
 
 	// ErrEmptyParameterTemplate is the empty parameter error message template

--- a/internal/restconf/builder_test.go
+++ b/internal/restconf/builder_test.go
@@ -176,20 +176,20 @@ func TestRESTCONFBuilderUnit_BuildQueryURL_Success(t *testing.T) {
 		{
 			name:       "MAC query",
 			endpoint:   "wtp-mac",
-			identifier: "aa:bb:cc:dd:ee:ff",
-			expected:   "wtp-mac=aa:bb:cc:dd:ee:ff",
+			identifier: "aa:bb:cc:dd:ee:01",
+			expected:   "wtp-mac=aa:bb:cc:dd:ee:01",
 		},
 		{
 			name:       "Dotted MAC query",
 			endpoint:   "wtp-mac",
-			identifier: "aabb.ccdd.eeff",
-			expected:   "wtp-mac=aabb.ccdd.eeff",
+			identifier: "aabb.ccdd.ee01",
+			expected:   "wtp-mac=aabb.ccdd.ee01",
 		},
 		{
 			name:       "Bare MAC query",
 			endpoint:   "wtp-mac",
-			identifier: "aabbccddeeff",
-			expected:   "wtp-mac=aabbccddeeff",
+			identifier: "aabbccddee01",
+			expected:   "wtp-mac=aabbccddee01",
 		},
 		{
 			name:       "Profile name carrying a space",
@@ -256,8 +256,8 @@ func TestRESTCONFBuilderUnit_BuildQueryCompositeURL_Success(t *testing.T) {
 		{
 			name:     "Mixed types",
 			endpoint: "query",
-			values:   []interface{}{"aa:bb:cc:dd:ee:ff", 0, true},
-			expected: "query=aa:bb:cc:dd:ee:ff,0,true",
+			values:   []interface{}{"aa:bb:cc:dd:ee:01", 0, true},
+			expected: "query=aa:bb:cc:dd:ee:01,0,true",
 		},
 		{
 			name:     "Single value",

--- a/internal/service/base_test.go
+++ b/internal/service/base_test.go
@@ -11,7 +11,7 @@ func TestServiceBaseUnit_Constructor_Success(t *testing.T) {
 	t.Run("NewBaseService", func(t *testing.T) {
 		t.Run("WithValidClient", func(t *testing.T) {
 			// Create mock client instead of real client
-			mockClient, _ := core.New("localhost", "test-token", core.WithInsecureSkipVerify(true))
+			mockClient, _ := core.New("localhost", "test-token-123", core.WithInsecureSkipVerify(true))
 			service := NewBaseService(mockClient)
 
 			testutil.AssertPointerEquals(
@@ -32,7 +32,7 @@ func TestServiceBaseUnit_Constructor_Success(t *testing.T) {
 	t.Run("Client", func(t *testing.T) {
 		t.Run("ReturnsValidClient", func(t *testing.T) {
 			// Create mock client instead of real client
-			mockClient, _ := core.New("localhost", "test-token", core.WithInsecureSkipVerify(true))
+			mockClient, _ := core.New("localhost", "test-token-123", core.WithInsecureSkipVerify(true))
 			service := NewBaseService(mockClient)
 
 			retrievedClient := service.Client()
@@ -66,7 +66,7 @@ func TestServiceBaseUnit_Constructor_Success(t *testing.T) {
 
 		t.Run("EmbeddingWithValidClient", func(t *testing.T) {
 			// Create mock client instead of real client
-			mockClient, _ := core.New("localhost", "test-token", core.WithInsecureSkipVerify(true))
+			mockClient, _ := core.New("localhost", "test-token-123", core.WithInsecureSkipVerify(true))
 			testService := newTestService(mockClient)
 
 			testutil.AssertPointerEquals(t, testService.Client(), mockClient,

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestClientUnit_NewRequestBuilder_Success(t *testing.T) {
 	t.Run("ValidParams", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		rb := NewRequestBuilder(restBuilder, "token", "", slog.Default())
 		testutil.AssertNotNil(t, rb, "NewRequestBuilder result")
 	})
@@ -26,7 +26,7 @@ func TestClientUnit_NewRequestBuilder_Success(t *testing.T) {
 
 func TestClientUnit_RequestBuilderCreateRequestWithPayload_Success(t *testing.T) {
 	t.Run("ValidPayload", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -51,7 +51,7 @@ func TestClientUnit_RequestBuilderCreateRequestWithPayload_Success(t *testing.T)
 
 func TestClientUnit_RequestBuilderCreateRPCRequestWithPayload_Success(t *testing.T) {
 	t.Run("ValidRPCPayload", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -74,7 +74,7 @@ func TestClientUnit_RequestBuilderCreateRPCRequestWithPayload_Success(t *testing
 	})
 
 	t.Run("InvalidHTTPMethodWithNilPayload", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -87,7 +87,7 @@ func TestClientUnit_RequestBuilderCreateRPCRequestWithPayload_Success(t *testing
 
 func TestClientUnit_RequestBuilderExecuteRequest_Success(t *testing.T) {
 	t.Run("NilRequest", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 		client := &http.Client{}
@@ -104,7 +104,7 @@ func TestClientUnit_RequestBuilderExecuteRequest_Success(t *testing.T) {
 // Test CreateRequest function.
 func TestClientUnit_RequestBuilderCreateRequest_Success(t *testing.T) {
 	t.Run("ValidRequest", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -123,7 +123,7 @@ func TestClientUnit_RequestBuilderCreateRequest_Success(t *testing.T) {
 	})
 
 	t.Run("InvalidHTTPMethod", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -146,7 +146,7 @@ func TestClientUnit_ExecuteRequestWithMockServer_Success(t *testing.T) {
 
 	restBuilder := restconf.NewBuilder("http", mockServer.URL[7:]) // Remove "http://"
 	logger := slog.Default()
-	rb := NewRequestBuilder(restBuilder, "test-token", "", logger)
+	rb := NewRequestBuilder(restBuilder, "test-token-123", "", logger)
 	client := mockServer.Client()
 
 	req, err := rb.CreateRequest(context.Background(), http.MethodGet, "test-endpoint")
@@ -163,7 +163,7 @@ func TestClientUnit_ExecuteRequestWithMockServer_Success(t *testing.T) {
 // Test CreateRequestWithPayload error scenarios.
 func TestClientUnit_CreateRequestWithPayload_ErrorScenarios(t *testing.T) {
 	t.Run("InvalidPayloadSerialization", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -181,7 +181,7 @@ func TestClientUnit_CreateRequestWithPayload_ErrorScenarios(t *testing.T) {
 	})
 
 	t.Run("NilPayload", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -205,7 +205,7 @@ func TestClientUnit_CreateRequestWithPayload_ErrorScenarios(t *testing.T) {
 // Test CreateRPCRequestWithPayload error scenarios.
 func TestClientUnit_CreateRPCRequestWithPayload_ErrorScenarios(t *testing.T) {
 	t.Run("InvalidPayloadSerialization", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -223,7 +223,7 @@ func TestClientUnit_CreateRPCRequestWithPayload_ErrorScenarios(t *testing.T) {
 	})
 
 	t.Run("NilPayload", func(t *testing.T) {
-		restBuilder := restconf.NewBuilder("https", "controller.example.com")
+		restBuilder := restconf.NewBuilder("https", "wnc1.example.internal")
 		logger := slog.Default()
 		rb := NewRequestBuilder(restBuilder, "token", "", logger)
 
@@ -256,7 +256,7 @@ func TestClientUnit_ExecuteRequest_ErrorScenarios(t *testing.T) {
 
 		restBuilder := restconf.NewBuilder("http", mockServer.URL[7:]) // Remove "http://"
 		logger := slog.Default()
-		rb := NewRequestBuilder(restBuilder, "test-token", "", logger)
+		rb := NewRequestBuilder(restBuilder, "test-token-123", "", logger)
 		client := mockServer.Client()
 
 		req, err := rb.CreateRequest(context.Background(), http.MethodGet, "test-endpoint")

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -29,7 +29,7 @@ func TestValidationUnit_GetOperations_Success(t *testing.T) {
 	testutil.AssertNoError(t, ValidateHost("192.168.1.100"), "IP controller")
 
 	// Token validation
-	testutil.AssertBoolEquals(t, IsValidAccessToken("valid-token"), true, "valid token")
+	testutil.AssertBoolEquals(t, IsValidAccessToken("test-token-123"), true, "valid token")
 	testutil.AssertBoolEquals(t, IsValidAccessToken(""), false, "empty token")
 	testutil.AssertBoolEquals(t, IsValidAccessToken("short"), true, "short token is valid (only checks non-empty)")
 
@@ -137,8 +137,8 @@ func TestValidationUnit_ValidationErrors_Success(t *testing.T) {
 	)
 
 	// Composite validation scenarios
-	controller := "test.cisco.com"
-	token := "test-token"
+	controller := "wnc1.example.internal"
+	token := "test-token-123"
 	testutil.AssertBoolEquals(
 		t,
 		ValidateHost(controller) == nil && IsValidAccessToken(token),

--- a/pkg/testutil/testing.go
+++ b/pkg/testutil/testing.go
@@ -140,7 +140,7 @@ func NewTestClient(server MockServer) TestClient {
 		panic("testutil: failed to parse server URL: " + err.Error())
 	}
 
-	client, err := core.New(u.Host, "test-token", core.WithInsecureSkipVerify(true))
+	client, err := core.New(u.Host, "test-token-123", core.WithInsecureSkipVerify(true))
 	if err != nil {
 		panic("testutil: failed to create test client: " + err.Error())
 	}

--- a/service/afc/service_test.go
+++ b/service/afc/service_test.go
@@ -52,13 +52,13 @@ func TestAfcServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-afc-oper:afc-oper-data/ewlc-afc-ap-resp": `{
 			"Cisco-IOS-XE-wireless-afc-oper:ewlc-afc-ap-resp": [{
-				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"ap-mac": "aa:bb:cc:dd:ee:01",
 				"response-status": "success"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-afc-oper:afc-oper-data/ewlc-afc-ap-req": `{
 			"Cisco-IOS-XE-wireless-afc-oper:ewlc-afc-ap-req": [{
-				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"ap-mac": "aa:bb:cc:dd:ee:01",
 				"request-status": "pending"
 			}]
 		}`,
@@ -198,7 +198,7 @@ func TestAfcServiceUnit_QuotedDecimal64_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-afc-oper:afc-oper-data/ewlc-afc-ap-req": `{
 			"Cisco-IOS-XE-wireless-afc-oper:ewlc-afc-ap-req": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"req-id-sent": "18446744073709551615",
 					"req-data": {
 						"min-desired-power": "-12.5",
@@ -258,7 +258,7 @@ func TestAfcServiceUnit_QuotedMaxEIRP_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-afc-oper:afc-oper-data/ewlc-afc-ap-resp": `{
 			"Cisco-IOS-XE-wireless-afc-oper:ewlc-afc-ap-resp": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"slot": 2,
 					"resp-data": {
 						"request-id": "1",

--- a/service/ap/service_test.go
+++ b/service/ap/service_test.go
@@ -50,10 +50,10 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data": {
 				"ap-tags": {
 					"ap-tag": [{
-						"ap-mac": "28:ac:9e:11:48:10",
-						"policy-tag": "labo-wlan-flex",
-						"site-tag": "labo-site-flex",
-						"rf-tag": "labo-inside"
+						"ap-mac": "aa:bb:cc:dd:ee:02",
+						"policy-tag": "test-wlan-flex",
+						"site-tag": "test-site-flex",
+						"rf-tag": "test-inside"
 					}]
 				},
 				"tag-source-priority-configs": {
@@ -67,15 +67,15 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags": `{
 			"Cisco-IOS-XE-wireless-ap-cfg:ap-tags": {
 				"ap-tag": [{
-					"ap-mac": "28:ac:9e:11:48:10",
-					"policy-tag": "labo-wlan-flex",
-					"site-tag": "labo-site-flex",
-					"rf-tag": "labo-inside"
+					"ap-mac": "aa:bb:cc:dd:ee:02",
+					"policy-tag": "test-wlan-flex",
+					"site-tag": "test-site-flex",
+					"rf-tag": "test-inside"
 				}, {
-					"ap-mac": "c4:14:a2:c9:02:70",
-					"policy-tag": "labo-wlan-flex",
-					"site-tag": "labo-site-flex",
-					"rf-tag": "labo-inside"
+					"ap-mac": "aa:bb:cc:dd:ee:02",
+					"policy-tag": "test-wlan-flex",
+					"site-tag": "test-site-flex",
+					"rf-tag": "test-inside"
 				}]
 			}
 		}`,
@@ -95,15 +95,15 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"ap-down": 0
 				},
 				"ap-history": [{
-					"ethernet-mac": "28:ac:9e:11:48:10",
+					"ethernet-mac": "aa:bb:cc:dd:ee:12",
 					"ap-name": "TEST-AP01",
-					"wtp-mac": "aa:bb:cc:dd:ee:ff"
+					"wtp-mac": "aa:bb:cc:dd:ee:01"
 				}],
 				"ap-join-stats": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"ap-join-info": {
-						"ap-ip-addr": "192.168.255.11",
-						"ap-ethernet-mac": "28:ac:9e:11:48:10",
+						"ap-ip-addr": "192.168.1.11",
+						"ap-ethernet-mac": "aa:bb:cc:dd:ee:12",
 						"ap-name": "TEST-AP01",
 						"is-joined": true
 					}
@@ -123,17 +123,17 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-history": `{
 			"Cisco-IOS-XE-wireless-ap-global-oper:ap-history": [{
-				"ethernet-mac": "28:ac:9e:11:48:10",
+				"ethernet-mac": "aa:bb:cc:dd:ee:12",
 				"ap-name": "TEST-AP01",
-				"wtp-mac": "aa:bb:cc:dd:ee:ff"
+				"wtp-mac": "aa:bb:cc:dd:ee:01"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-join-stats": `{
 			"Cisco-IOS-XE-wireless-ap-global-oper:ap-join-stats": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"ap-join-info": {
-					"ap-ip-addr": "192.168.255.11",
-					"ap-ethernet-mac": "28:ac:9e:11:48:10",
+					"ap-ip-addr": "192.168.1.11",
+					"ap-ethernet-mac": "aa:bb:cc:dd:ee:12",
 					"ap-name": "TEST-AP01",
 					"is-joined": true
 				}
@@ -148,7 +148,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data": {
 				"oper-data": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-id": 4,
 					"ap-antenna-band-mode": "ant-band-mode-unknown",
 					"link-encryption-enabled": false,
@@ -158,22 +158,22 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 						"mtu": 1485,
 						"is-static-ap-ipaddr": true,
 						"domain-name": "",
-						"ap-ip-addr": "192.168.255.11",
+						"ap-ip-addr": "192.168.1.11",
 						"ap-ipv6-addr": "::",
 						"ap-ip-netmask": "255.255.255.0",
-						"ap-ip-gateway": "192.168.255.1",
+						"ap-ip-gateway": "192.168.1.1",
 						"ap-ipv6-gateway": "::",
 						"ap-name-server-type": "unknown",
 						"ap-ipv6-method": "unknown-method",
-						"static-ip": "192.168.255.11",
-						"static-gw-ip": "192.168.255.1",
+						"static-ip": "192.168.1.11",
+						"static-gw-ip": "192.168.1.1",
 						"static-netmask": "255.255.255.0",
 						"static-prefix": 0
 					},
 					"ap-prime-info": {
 						"primary-controller-name": "WNC1",
 						"secondary-controller-name": "",
-						"primary-controller-ip-addr": "192.168.255.1",
+						"primary-controller-ip-addr": "192.168.1.100",
 						"secondary-controller-ip-addr": "0.0.0.0",
 						"tertiary-controller-name": "",
 						"tertiary-controller-ip-addr": "0.0.0.0",
@@ -192,25 +192,25 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"is-local-net": false
 				}],
 				"capwap-data": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
-					"ip-addr": "192.168.255.11",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
+					"ip-addr": "192.168.1.11",
 					"name": "TEST-AP01",
 					"device-detail": {
 						"static-info": {
 							"board-data": {
 								"wtp-serial-num": "FGL2209B05T",
-								"wtp-enet-mac": "28:ac:9e:11:48:10"
+								"wtp-enet-mac": "aa:bb:cc:dd:ee:12"
 							}
 						}
 					}
 				}],
 				"ap-name-mac-map": [{
 					"wtp-name": "TEST-AP01",
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
-					"eth-mac": "28:ac:9e:11:48:10"
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
+					"eth-mac": "aa:bb:cc:dd:ee:12"
 				}],
 				"radio-oper-data": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0,
 					"slot-id": 0,
 					"radio-type": "radio-80211bg",
@@ -218,28 +218,28 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"oper-state": "radio-up"
 				}],
 				"ap-radio-neighbor": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0,
-					"bssid": "aa:bb:cc:dd:ee:ff"
+					"bssid": "aa:bb:cc:dd:ee:01"
 				}],
 				"ap-image-active-location": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"image-location": "flash:/c9800-universal-k9.16.12.07.SPA.bin"
 				}],
 				"ap-image-prepare-location": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"image-location": "flash:/c9800-universal-k9.16.12.07.SPA.bin"
 				}],
 				"ap-pwr-info": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"power-consumption": 20.5
 				}],
 				"ap-sensor-status": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"temperature": 42
 				}],
 				"capwap-pkts": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"tx-pkts": 1000,
 					"rx-pkts": 950
 				}]
@@ -247,7 +247,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/oper-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:oper-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-id": 4,
 				"ap-antenna-band-mode": "ant-band-mode-unknown",
 				"link-encryption-enabled": false,
@@ -257,22 +257,22 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"mtu": 1485,
 					"is-static-ap-ipaddr": true,
 					"domain-name": "",
-					"ap-ip-addr": "192.168.255.11",
+					"ap-ip-addr": "192.168.1.11",
 					"ap-ipv6-addr": "::",
 					"ap-ip-netmask": "255.255.255.0",
-					"ap-ip-gateway": "192.168.255.1",
+					"ap-ip-gateway": "192.168.1.1",
 					"ap-ipv6-gateway": "::",
 					"ap-name-server-type": "unknown",
 					"ap-ipv6-method": "unknown-method",
-					"static-ip": "192.168.255.11",
-					"static-gw-ip": "192.168.255.1",
+					"static-ip": "192.168.1.11",
+					"static-gw-ip": "192.168.1.1",
 					"static-netmask": "255.255.255.0",
 					"static-prefix": 0
 				},
 				"ap-prime-info": {
 					"primary-controller-name": "WNC1",
 					"secondary-controller-name": "",
-					"primary-controller-ip-addr": "192.168.255.1",
+					"primary-controller-ip-addr": "192.168.1.100",
 					"secondary-controller-ip-addr": "0.0.0.0",
 					"tertiary-controller-name": "",
 					"tertiary-controller-ip-addr": "0.0.0.0",
@@ -293,14 +293,14 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
-				"ip-addr": "192.168.255.11",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
+				"ip-addr": "192.168.1.11",
 				"name": "TEST-AP01",
 				"device-detail": {
 					"static-info": {
 						"board-data": {
 							"wtp-serial-num": "FGL2209B05T",
-							"wtp-enet-mac": "28:ac:9e:11:48:10"
+							"wtp-enet-mac": "aa:bb:cc:dd:ee:12"
 						}
 					}
 				}
@@ -309,50 +309,50 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-name-mac-map": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-name-mac-map": [{
 				"wtp-name": "AP-Test-01",
-				"wtp-mac": "aa:bb:cc:dd:ee:ff"
+				"wtp-mac": "aa:bb:cc:dd:ee:01"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-oper-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
 				"oper-state": "up"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-radio-neighbor": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
-				"bssid": "bb:cc:dd:ee:ff:aa"
+				"bssid": "aa:bb:cc:dd:ee:03"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-image-active-location": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-image-active-location": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"image-location": "flash:ap3g2-k9w8-mx.152-4.JB6"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-image-prepare-location": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-image-prepare-location": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"image-location": "flash:ap3g2-k9w8-mx.152-4.JB6"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-pwr-info": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-pwr-info": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"power-consumption": 15.5
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-sensor-status": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-sensor-status": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"temperature": 45
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-pkts": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-pkts": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"tx-pkts": 1000,
 				"rx-pkts": 2000
 			}]
@@ -360,7 +360,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/iot-firmware": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:iot-firmware": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"if-name": "ttyiot0",
 					"is-default": [null],
 					"version": "2.7.21",
@@ -369,7 +369,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"desc": "Firmware developed by Cisco for IoT use"
 				},
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"if-name": "ttyiot0",
 					"is-default": [null],
 					"version": "3.1.0",
@@ -383,7 +383,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-reset-stats": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-reset-stats": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"radio-id": 0,
 					"cause": "none",
 					"detail-cause": "none",
@@ -394,7 +394,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/qos-client-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:qos-client-data": [
 				{
-					"client-mac": "80:7d:3a:77:19:a9",
+					"client-mac": "aa:bb:cc:dd:ee:a1",
 					"aaa-qos-params": {
 						"aaa-avgdtus": 0,
 						"aaa-avgrtdtus": 0,
@@ -411,7 +411,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/wtp-slot-wlan-stats": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:wtp-slot-wlan-stats": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"slot-id": 0,
 					"wlan-id": 1,
 					"tx-bytes": 123456,
@@ -422,15 +422,15 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ethernet-mac-wtp-mac-map": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ethernet-mac-wtp-mac-map": [
 				{
-					"ethernet-mac": "aa:bb:cc:dd:ee:ff",
-					"wtp-mac": "bb:cc:dd:ee:ff:aa"
+					"ethernet-mac": "aa:bb:cc:dd:ee:11",
+					"wtp-mac": "aa:bb:cc:dd:ee:03"
 				}
 			]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-stats": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-oper-stats": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"slot-id": 0,
 					"tx-frames": 100,
 					"rx-frames": 200
@@ -440,7 +440,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ethernet-if-stats": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ethernet-if-stats": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"if-id": "GigabitEthernet0",
 					"tx-bytes": 987654,
 					"rx-bytes": 456789
@@ -465,7 +465,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-iox-oper-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-iox-oper-data": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"app-name": "test-app",
 					"state": "running"
 				}
@@ -499,7 +499,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/rlan-oper": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:rlan-oper": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"rlan-port-id": 1,
 					"rlan-oper-state": true,
 					"rlan-port-status": true
@@ -516,7 +516,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/cdp-cache-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:cdp-cache-data": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"local-intf-name": "GigabitEthernet0",
 					"device-id": "Switch1"
 				}
@@ -525,7 +525,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/lldp-neigh": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:lldp-neigh": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"local-intf-name": "GigabitEthernet0",
 					"device-id": "Switch1"
 				}
@@ -546,7 +546,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/disc-data": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:disc-data": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"disc-req": 10,
 					"disc-rsp": 10
 				}
@@ -555,7 +555,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/country-oper": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:country-oper": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-id": 0,
 					"country-code": "US",
 					"regulatory-domain": "FCC"
@@ -565,7 +565,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/supp-country-oper": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:supp-country-oper": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-id": 0,
 					"country-code": "US",
 					"supported-channels": "1,6,11"
@@ -1202,7 +1202,7 @@ func TestApServiceUnit_GetOperations_ErrorHandling(t *testing.T) {
 
 	// Test GetBy* filtered functions error handling
 	t.Run("GetRadioResetStatsByAPMACAndRadioID", func(t *testing.T) {
-		_, err := service.GetRadioResetStatsByAPMACAndRadioID(ctx, "aa:bb:cc:dd:ee:ff", 0)
+		_, err := service.GetRadioResetStatsByAPMACAndRadioID(ctx, "aa:bb:cc:dd:ee:01", 0)
 		if err == nil {
 			t.Error("Expected error for 404 response, got nil")
 		}
@@ -1212,7 +1212,7 @@ func TestApServiceUnit_GetOperations_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("GetQosClientDataByClientMAC", func(t *testing.T) {
-		_, err := service.GetQosClientDataByClientMAC(ctx, "80:7d:3a:77:19:a9")
+		_, err := service.GetQosClientDataByClientMAC(ctx, "aa:bb:cc:dd:ee:a1")
 		if err == nil {
 			t.Error("Expected error for 404 response, got nil")
 		}
@@ -1228,7 +1228,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	responses := map[string]string{
 		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa%3Abb%3Acc%3Add%3Aee%3Aff": `{
 			"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": {
-				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"ap-mac": "aa:bb:cc:dd:ee:01",
 				"site-tag": "building1",
 				"policy-tag": "default-policy",
 				"rf-tag": "typical"
@@ -1242,13 +1242,13 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data?content=config&fields=ap-history(ethernet-mac;ip-addr)&ap-history=aa%3Abb%3Acc%3Add%3Aee%3Aff": `{
 			"Cisco-IOS-XE-wireless-ap-global-oper:ap-history": [{
-				"ethernet-mac": "aa:bb:cc:dd:ee:ff",
+				"ethernet-mac": "aa:bb:cc:dd:ee:11",
 				"ip-addr": "192.168.1.100"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-join-stats=aa%3Abb%3Acc%3Add%3Aee%3Aff": `{
 			"Cisco-IOS-XE-wireless-ap-global-oper:ap-join-stats": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"join-time": "2023-01-01T00:00:00Z"
 			}]
 		}`,
@@ -1260,7 +1260,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data?content=config&fields=capwap-data(wtp-mac;name;ip-addr)&capwap-data=aa%3Abb%3Acc%3Add%3Aee%3Aff": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"ip-addr": "192.168.1.100",
 				"name": "AP-Test-01"
 			}]
@@ -1268,62 +1268,62 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-name-mac-map?content=config&fields=ap-name-mac-map(wtp-name;wtp-mac)&ap-name-mac-map=AP-Test-01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-name-mac-map": [{
 				"wtp-name": "AP-Test-01",
-				"wtp-mac": "aa:bb:cc:dd:ee:ff"
+				"wtp-mac": "aa:bb:cc:dd:ee:01"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-data?content=config&fields=radio-oper-data(wtp-mac;radio-slot-id;oper-state)&radio-oper-data=aa%3Abb%3Acc%3Add%3Aee%3Aff%2C0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-oper-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
 				"oper-state": "up"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor?content=config&fields=ap-radio-neighbor(wtp-mac;radio-slot-id;bssid)&ap-radio-neighbor=aa%3Abb%3Acc%3Add%3Aee%3Aff%2C0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-radio-neighbor": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
-				"bssid": "bb:cc:dd:ee:ff:aa"
+				"bssid": "aa:bb:cc:dd:ee:03"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor?content=config&fields=ap-radio-neighbor(wtp-mac;radio-slot-id;bssid)&ap-radio-neighbor=aa%3Abb%3Acc%3Add%3Aee%3Aff%2C0%2Cbb%3Acc%3Add%3Aee%3Aff%3Aaa": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-radio-neighbor": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
-				"bssid": "bb:cc:dd:ee:ff:aa"
+				"bssid": "aa:bb:cc:dd:ee:03"
 			}]
 		}`,
 		// AP tag query endpoints
 		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags?ap-tag=28%3Aac%3A9e%3A11%3A48%3A10": `{
 			"Cisco-IOS-XE-wireless-ap-cfg:ap-tags": {
 				"ap-tag": [{
-					"ap-mac": "28:ac:9e:11:48:10",
-					"policy-tag": "labo-wlan-flex",
-					"site-tag": "labo-site-flex",
-					"rf-tag": "labo-inside"
+					"ap-mac": "aa:bb:cc:dd:ee:02",
+					"policy-tag": "test-wlan-flex",
+					"site-tag": "test-site-flex",
+					"rf-tag": "test-inside"
 				}]
 			}
 		}`,
-		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=28:ac:9e:11:48:10": `{
+		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:02": `{
 			"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
-				"ap-mac": "28:ac:9e:11:48:10",
-				"policy-tag": "labo-wlan-flex",
-				"site-tag": "labo-site-flex",
-				"rf-tag": "labo-inside"
+				"ap-mac": "aa:bb:cc:dd:ee:02",
+				"policy-tag": "test-wlan-flex",
+				"site-tag": "test-site-flex",
+				"rf-tag": "test-inside"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-history=28:ac:9e:11:48:10": `{
+		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-history=aa:bb:cc:dd:ee:02": `{
 			"Cisco-IOS-XE-wireless-ap-global-oper:ap-history": [{
-				"ethernet-mac": "28:ac:9e:11:48:10",
+				"ethernet-mac": "aa:bb:cc:dd:ee:12",
 				"ap-name": "TEST-AP01",
-				"wtp-mac": "aa:bb:cc:dd:ee:ff"
+				"wtp-mac": "aa:bb:cc:dd:ee:01"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-join-stats=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-ap-global-oper:ap-global-oper-data/ap-join-stats=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-ap-global-oper:ap-join-stats": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"ap-join-info": {
-					"ap-ip-addr": "192.168.255.11",
-					"ap-ethernet-mac": "28:ac:9e:11:48:10",
+					"ap-ip-addr": "192.168.1.11",
+					"ap-ethernet-mac": "aa:bb:cc:dd:ee:12",
 					"ap-name": "TEST-AP01",
 					"is-joined": true
 				}
@@ -1335,23 +1335,23 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 				"client-count": 0
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
-				"ip-addr": "192.168.255.11",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
+				"ip-addr": "192.168.1.11",
 				"name": "TEST-AP01"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-name-mac-map=TEST-AP01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-name-mac-map": [{
 				"wtp-name": "TEST-AP01",
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
-				"eth-mac": "28:ac:9e:11:48:10"
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
+				"eth-mac": "aa:bb:cc:dd:ee:12"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-data=aa:bb:cc:dd:ee:ff,0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-data=aa:bb:cc:dd:ee:01,0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-oper-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
 				"slot-id": 0,
 				"radio-type": "radio-80211bg",
@@ -1359,35 +1359,35 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 				"oper-state": "radio-up"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor=aa:bb:cc:dd:ee:ff,0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor=aa:bb:cc:dd:ee:01,0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-radio-neighbor": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
-				"bssid": "aa:bb:cc:dd:ee:ff"
+				"bssid": "aa:bb:cc:dd:ee:01"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor=aa:bb:cc:dd:ee:ff,0,aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-radio-neighbor=aa:bb:cc:dd:ee:01,0,aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-radio-neighbor": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-slot-id": 0,
-				"bssid": "aa:bb:cc:dd:ee:ff"
+				"bssid": "aa:bb:cc:dd:ee:01"
 			}]
 		}`,
 		// PUT/POST endpoints for tag assignment
-		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tag=aa:bb:cc:dd:ee:ff": `{}`,
+		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tag=aa:bb:cc:dd:ee:01": `{}`,
 		// New filtered endpoints
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-reset-stats=aa:bb:cc:dd:ee:ff,0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-reset-stats=aa:bb:cc:dd:ee:01,0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-reset-stats": [{
-				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"ap-mac": "aa:bb:cc:dd:ee:01",
 				"radio-id": 0,
 				"cause": "none",
 				"detail-cause": "none",
 				"count": 0
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/qos-client-data=80:7d:3a:77:19:a9": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/qos-client-data=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:qos-client-data": [{
-				"client-mac": "80:7d:3a:77:19:a9",
+				"client-mac": "aa:bb:cc:dd:ee:a1",
 				"aaa-qos-params": {
 					"aaa-avgdtus": 0,
 					"aaa-avgrtdtus": 0,
@@ -1400,84 +1400,84 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 				}
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/wtp-slot-wlan-stats=aa:bb:cc:dd:ee:ff,0,1": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/wtp-slot-wlan-stats=aa:bb:cc:dd:ee:01,0,1": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:wtp-slot-wlan-stats": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"slot-id": 0,
 				"wlan-id": 1,
 				"tx-bytes": 123456,
 				"rx-bytes": 654321
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ethernet-mac-wtp-mac-map=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ethernet-mac-wtp-mac-map=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ethernet-mac-wtp-mac-map": [{
-				"ethernet-mac": "aa:bb:cc:dd:ee:ff",
-				"wtp-mac": "bb:cc:dd:ee:ff:aa"
+				"ethernet-mac": "aa:bb:cc:dd:ee:11",
+				"wtp-mac": "aa:bb:cc:dd:ee:03"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-stats=aa:bb:cc:dd:ee:ff,0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/radio-oper-stats=aa:bb:cc:dd:ee:01,0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:radio-oper-stats": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"slot-id": 0,
 				"tx-frames": 100,
 				"rx-frames": 200
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ethernet-if-stats=aa:bb:cc:dd:ee:ff,GigabitEthernet0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ethernet-if-stats=aa:bb:cc:dd:ee:01,GigabitEthernet0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ethernet-if-stats": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"if-id": "GigabitEthernet0",
 				"tx-bytes": 987654,
 				"rx-bytes": 456789
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-iox-oper-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/ap-iox-oper-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:ap-iox-oper-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"app-name": "test-app",
 				"state": "running"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/rlan-oper=aa:bb:cc:dd:ee:ff,1": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/rlan-oper=aa:bb:cc:dd:ee:01,1": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:rlan-oper": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"rlan-port-id": 1,
 				"rlan-oper-state": true,
 				"rlan-port-status": true
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/cdp-cache-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/cdp-cache-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:cdp-cache-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"local-intf-name": "GigabitEthernet0",
 				"device-id": "Switch1"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/lldp-neigh=aa:bb:cc:dd:ee:ff,11:22:33:44:55:66": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/lldp-neigh=aa:bb:cc:dd:ee:01,aa:bb:cc:dd:ee:02": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:lldp-neigh": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
-				"neigh-mac": "11:22:33:44:55:66",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
+				"neigh-mac": "aa:bb:cc:dd:ee:02",
 				"local-port": "GigabitEthernet0"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/disc-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/disc-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:disc-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"disc-req": 10,
 				"disc-rsp": 10
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/country-oper=aa:bb:cc:dd:ee:ff,0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/country-oper=aa:bb:cc:dd:ee:01,0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:country-oper": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-id": 0,
 				"country-code": "US",
 				"regulatory-domain": "FCC"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/supp-country-oper=aa:bb:cc:dd:ee:ff,0": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/supp-country-oper=aa:bb:cc:dd:ee:01,0": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:supp-country-oper": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"radio-id": 0,
 				"country-code": "US",
 				"supported-channels": "1,6,11"
@@ -1493,7 +1493,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 
 	// Test filtered configuration operations
 	t.Run("GetTagConfigByMAC", func(t *testing.T) {
-		result, err := service.GetTagConfigByMAC(ctx, "28:ac:9e:11:48:10")
+		result, err := service.GetTagConfigByMAC(ctx, "aa:bb:cc:dd:ee:02")
 		if err != nil {
 			t.Errorf("Expected no error for GetTagConfigByMAC, got: %v", err)
 		}
@@ -1504,7 +1504,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 
 	// Test individual filtered operations that were missing
 	t.Run("GetDiscDataByWTPMAC", func(t *testing.T) {
-		result, err := service.GetDiscDataByWTPMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		result, err := service.GetDiscDataByWTPMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for GetDiscDataByWTPMAC, got: %v", err)
 		}
@@ -1514,7 +1514,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetCountryOperByWTPMACAndRadioID", func(t *testing.T) {
-		result, err := service.GetCountryOperByWTPMACAndRadioID(ctx, "aa:bb:cc:dd:ee:ff", 0)
+		result, err := service.GetCountryOperByWTPMACAndRadioID(ctx, "aa:bb:cc:dd:ee:01", 0)
 		if err != nil {
 			t.Errorf("Expected no error for GetCountryOperByWTPMACAndRadioID, got: %v", err)
 		}
@@ -1524,7 +1524,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetSuppCountryOperByWTPMACAndRadioID", func(t *testing.T) {
-		result, err := service.GetSuppCountryOperByWTPMACAndRadioID(ctx, "aa:bb:cc:dd:ee:ff", 0)
+		result, err := service.GetSuppCountryOperByWTPMACAndRadioID(ctx, "aa:bb:cc:dd:ee:01", 0)
 		if err != nil {
 			t.Errorf("Expected no error for GetSuppCountryOperByWTPMACAndRadioID, got: %v", err)
 		}
@@ -1534,7 +1534,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetLldpNeighByWTPMACAndNeighMAC", func(t *testing.T) {
-		result, err := service.GetLldpNeighByWTPMACAndNeighMAC(ctx, "aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66")
+		result, err := service.GetLldpNeighByWTPMACAndNeighMAC(ctx, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02")
 		if err != nil {
 			t.Errorf("Expected no error for GetLldpNeighByWTPMACAndNeighMAC, got: %v", err)
 		}
@@ -1544,7 +1544,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetCdpCacheDataByWTPMAC", func(t *testing.T) {
-		result, err := service.GetCdpCacheDataByWTPMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		result, err := service.GetCdpCacheDataByWTPMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for GetCdpCacheDataByWTPMAC, got: %v", err)
 		}
@@ -1554,7 +1554,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetApIoxOperDataByWTPMAC", func(t *testing.T) {
-		result, err := service.GetApIoxOperDataByWTPMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		result, err := service.GetApIoxOperDataByWTPMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for GetApIoxOperDataByWTPMAC, got: %v", err)
 		}
@@ -1564,7 +1564,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetRadioOperStatsByWTPMACAndSlot", func(t *testing.T) {
-		result, err := service.GetRadioOperStatsByWTPMACAndSlot(ctx, "aa:bb:cc:dd:ee:ff", 0)
+		result, err := service.GetRadioOperStatsByWTPMACAndSlot(ctx, "aa:bb:cc:dd:ee:01", 0)
 		if err != nil {
 			t.Errorf("Expected no error for GetRadioOperStatsByWTPMACAndSlot, got: %v", err)
 		}
@@ -1574,7 +1574,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetEthernetMACWtpMACMapByEthernetMAC", func(t *testing.T) {
-		result, err := service.GetEthernetMACWtpMACMapByEthernetMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		result, err := service.GetEthernetMACWtpMACMapByEthernetMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for GetEthernetMACWtpMACMapByEthernetMAC, got: %v", err)
 		}
@@ -1584,7 +1584,7 @@ func TestApServiceUnit_GetOperations_FilteredSuccess(t *testing.T) {
 	})
 
 	t.Run("GetEthernetIfStatsByWTPMACAndInterfaceID", func(t *testing.T) {
-		result, err := service.GetEthernetIfStatsByWTPMACAndInterfaceID(ctx, "aa:bb:cc:dd:ee:ff", "GigabitEthernet0")
+		result, err := service.GetEthernetIfStatsByWTPMACAndInterfaceID(ctx, "aa:bb:cc:dd:ee:01", "GigabitEthernet0")
 		if err != nil {
 			t.Errorf("Expected no error for GetEthernetIfStatsByWTPMACAndInterfaceID, got: %v", err)
 		}
@@ -1668,21 +1668,21 @@ func TestApServiceUnit_GetOperations_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("GetRadioNeighborByAPMACSlotAndBSSID_EmptyMAC", func(t *testing.T) {
-		_, err := service.GetRadioNeighborByAPMACSlotAndBSSID(ctx, "", 0, "bb:cc:dd:ee:ff:aa")
+		_, err := service.GetRadioNeighborByAPMACSlotAndBSSID(ctx, "", 0, "aa:bb:cc:dd:ee:03")
 		if err == nil {
 			t.Error("Expected error for empty MAC address, got nil")
 		}
 	})
 
 	t.Run("GetRadioNeighborByAPMACSlotAndBSSID_EmptyBSSID", func(t *testing.T) {
-		_, err := service.GetRadioNeighborByAPMACSlotAndBSSID(ctx, "aa:bb:cc:dd:ee:ff", 0, "")
+		_, err := service.GetRadioNeighborByAPMACSlotAndBSSID(ctx, "aa:bb:cc:dd:ee:01", 0, "")
 		if err == nil {
 			t.Error("Expected error for empty BSSID, got nil")
 		}
 	})
 
 	t.Run("GetRadioNeighborByAPMACSlotAndBSSID_InvalidMAC", func(t *testing.T) {
-		_, err := service.GetRadioNeighborByAPMACSlotAndBSSID(ctx, "invalid-mac", 0, "bb:cc:dd:ee:ff:aa")
+		_, err := service.GetRadioNeighborByAPMACSlotAndBSSID(ctx, "invalid-mac", 0, "aa:bb:cc:dd:ee:03")
 		if err == nil {
 			t.Error("Expected error for invalid MAC address, got nil")
 		}
@@ -1725,7 +1725,7 @@ func TestApServiceUnit_GetOperations_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("GetWtpSlotWlanStatsByWTPMACSlotAndWLANID_InvalidWLANID", func(t *testing.T) {
-		_, err := service.GetWtpSlotWlanStatsByWTPMACSlotAndWLANID(ctx, "aa:bb:cc:dd:ee:ff", 0, 0)
+		_, err := service.GetWtpSlotWlanStatsByWTPMACSlotAndWLANID(ctx, "aa:bb:cc:dd:ee:01", 0, 0)
 		if err == nil {
 			t.Error("Expected error for invalid WLAN ID, got nil")
 		}
@@ -1753,7 +1753,7 @@ func TestApServiceUnit_GetOperations_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("GetEthernetIfStatsByWTPMACAndInterfaceID_EmptyInterfaceID", func(t *testing.T) {
-		_, err := service.GetEthernetIfStatsByWTPMACAndInterfaceID(ctx, "aa:bb:cc:dd:ee:ff", "")
+		_, err := service.GetEthernetIfStatsByWTPMACAndInterfaceID(ctx, "aa:bb:cc:dd:ee:01", "")
 		if err == nil {
 			t.Error("Expected error for empty interface ID, got nil")
 		}
@@ -1774,7 +1774,7 @@ func TestApServiceUnit_GetOperations_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("GetRlanOperByWTPMACAndPortID_InvalidPortID", func(t *testing.T) {
-		_, err := service.GetRlanOperByWTPMACAndPortID(ctx, "aa:bb:cc:dd:ee:ff", 0)
+		_, err := service.GetRlanOperByWTPMACAndPortID(ctx, "aa:bb:cc:dd:ee:01", 0)
 		if err == nil {
 			t.Error("Expected error for invalid port ID, got nil")
 		}
@@ -1788,14 +1788,14 @@ func TestApServiceUnit_GetOperations_ValidationErrors(t *testing.T) {
 	})
 
 	t.Run("GetLldpNeighByWTPMACAndNeighMAC_EmptyWTPMAC", func(t *testing.T) {
-		_, err := service.GetLldpNeighByWTPMACAndNeighMAC(ctx, "", "11:22:33:44:55:66")
+		_, err := service.GetLldpNeighByWTPMACAndNeighMAC(ctx, "", "aa:bb:cc:dd:ee:02")
 		if err == nil {
 			t.Error("Expected error for empty MAC address, got nil")
 		}
 	})
 
 	t.Run("GetLldpNeighByWTPMACAndNeighMAC_EmptyNeighMAC", func(t *testing.T) {
-		_, err := service.GetLldpNeighByWTPMACAndNeighMAC(ctx, "aa:bb:cc:dd:ee:ff", "")
+		_, err := service.GetLldpNeighByWTPMACAndNeighMAC(ctx, "aa:bb:cc:dd:ee:01", "")
 		if err == nil {
 			t.Error("Expected error for empty neighbor MAC address, got nil")
 		}
@@ -1865,17 +1865,17 @@ func TestApServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-access-point-cfg-rpc:set-ap-admin-state":      `{"status": "success"}`,
 		"Cisco-IOS-XE-wireless-access-point-cfg-rpc:set-ap-slot-admin-state": `{"status": "success"}`,
 		"Cisco-IOS-XE-wireless-access-point-cmd-rpc:ap-reset":                `{"status": "success"}`,
-		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
-				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"ap-mac": "aa:bb:cc:dd:ee:01",
 				"site-tag": "existing-site",
 				"policy-tag": "existing-policy",
 				"rf-tag": "existing-rf"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"name": "TEST-AP01"
 			}]
 		}`,
@@ -1889,14 +1889,14 @@ func TestApServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 
 	// Test AP admin state operations
 	t.Run("EnableAPByMAC", func(t *testing.T) {
-		err := service.EnableAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.EnableAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for EnableAPByMAC, got: %v", err)
 		}
 	})
 
 	t.Run("DisableAPByMAC", func(t *testing.T) {
-		err := service.DisableAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.DisableAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for DisableAPByMAC, got: %v", err)
 		}
@@ -1918,14 +1918,14 @@ func TestApServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 
 	// Test radio state operations
 	t.Run("EnableRadioByMAC", func(t *testing.T) {
-		err := service.EnableRadioByMAC(ctx, "aa:bb:cc:dd:ee:ff", 0, ap.RadioType80211BG)
+		err := service.EnableRadioByMAC(ctx, "aa:bb:cc:dd:ee:01", 0, ap.RadioType80211BG)
 		if err != nil {
 			t.Errorf("Expected no error for EnableRadioByMAC, got: %v", err)
 		}
 	})
 
 	t.Run("DisableRadioByMAC", func(t *testing.T) {
-		err := service.DisableRadioByMAC(ctx, "aa:bb:cc:dd:ee:ff", 1, ap.RadioType80211A)
+		err := service.DisableRadioByMAC(ctx, "aa:bb:cc:dd:ee:01", 1, ap.RadioType80211A)
 		if err != nil {
 			t.Errorf("Expected no error for DisableRadioByMAC, got: %v", err)
 		}
@@ -1933,21 +1933,21 @@ func TestApServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 
 	// Test tag assignment operations
 	t.Run("AssignSiteTag", func(t *testing.T) {
-		err := service.AssignSiteTag(ctx, "aa:bb:cc:dd:ee:ff", "labo-site-flex")
+		err := service.AssignSiteTag(ctx, "aa:bb:cc:dd:ee:01", "test-site-flex")
 		if err != nil {
 			t.Errorf("Expected no error for AssignSiteTag, got: %v", err)
 		}
 	})
 
 	t.Run("AssignPolicyTag", func(t *testing.T) {
-		err := service.AssignPolicyTag(ctx, "aa:bb:cc:dd:ee:ff", "labo-wlan-flex")
+		err := service.AssignPolicyTag(ctx, "aa:bb:cc:dd:ee:01", "test-wlan-flex")
 		if err != nil {
 			t.Errorf("Expected no error for AssignPolicyTag, got: %v", err)
 		}
 	})
 
 	t.Run("AssignRFTag", func(t *testing.T) {
-		err := service.AssignRFTag(ctx, "aa:bb:cc:dd:ee:ff", "labo-inside")
+		err := service.AssignRFTag(ctx, "aa:bb:cc:dd:ee:01", "test-inside")
 		if err != nil {
 			t.Errorf("Expected no error for AssignRFTag, got: %v", err)
 		}
@@ -1955,7 +1955,7 @@ func TestApServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 
 	// Test AP reset operation
 	t.Run("ResetAPByMAC", func(t *testing.T) {
-		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("Expected no error for ResetAPByMAC, got: %v", err)
 		}
@@ -2018,21 +2018,21 @@ func TestApServiceUnit_SetOperations_ValidationErrors(t *testing.T) {
 
 	// Test empty tag validation
 	t.Run("AssignSiteTag_EmptyTag", func(t *testing.T) {
-		err := service.AssignSiteTag(ctx, "aa:bb:cc:dd:ee:ff", "")
+		err := service.AssignSiteTag(ctx, "aa:bb:cc:dd:ee:01", "")
 		if err == nil {
 			t.Error("Expected error for empty site tag, got nil")
 		}
 	})
 
 	t.Run("AssignPolicyTag_EmptyTag", func(t *testing.T) {
-		err := service.AssignPolicyTag(ctx, "aa:bb:cc:dd:ee:ff", "")
+		err := service.AssignPolicyTag(ctx, "aa:bb:cc:dd:ee:01", "")
 		if err == nil {
 			t.Error("Expected error for empty policy tag, got nil")
 		}
 	})
 
 	t.Run("AssignRFTag_EmptyTag", func(t *testing.T) {
-		err := service.AssignRFTag(ctx, "aa:bb:cc:dd:ee:ff", "")
+		err := service.AssignRFTag(ctx, "aa:bb:cc:dd:ee:01", "")
 		if err == nil {
 			t.Error("Expected error for empty RF tag, got nil")
 		}
@@ -2066,7 +2066,7 @@ func TestApServiceUnit_SetOperations_ValidationErrors(t *testing.T) {
 func TestApServiceUnit_DoOperations_MockSuccess(t *testing.T) {
 	// Create mock server with specific responses for edge cases
 	responses := map[string]string{
-		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": []
 		}`,
 		"Cisco-IOS-XE-wireless-access-point-cmd-rpc:ap-reset": `{"status": "success"}`,
@@ -2080,7 +2080,7 @@ func TestApServiceUnit_DoOperations_MockSuccess(t *testing.T) {
 
 	// Test reset with empty CAPWAP data
 	t.Run("ResetAPByMAC_EmptyCAPWAPData", func(t *testing.T) {
-		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err == nil {
 			t.Error("Expected error for AP not found in CAPWAP data, got nil")
 		}
@@ -2090,7 +2090,7 @@ func TestApServiceUnit_DoOperations_MockSuccess(t *testing.T) {
 // TestApServiceUnit_DoOperations_ErrorHandling tests nil CAPWAP data handling.
 func TestApServiceUnit_DoOperations_ErrorHandling(t *testing.T) {
 	mockServer := testutil.NewMockServer(testutil.WithErrorResponses(
-		[]string{"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:ff"},
+		[]string{"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01"},
 		500,
 	))
 	defer mockServer.Close()
@@ -2101,7 +2101,7 @@ func TestApServiceUnit_DoOperations_ErrorHandling(t *testing.T) {
 
 	// Test reset with failed CAPWAP data retrieval
 	t.Run("ResetAPByMAC_FailedCAPWAPDataRetrieval", func(t *testing.T) {
-		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err == nil {
 			t.Error("Expected error for failed CAPWAP data retrieval, got nil")
 		}
@@ -2113,7 +2113,7 @@ func TestApServiceUnit_ResetAP_EdgeCases(t *testing.T) {
 	// Test Reset with nil CAPWAP data response
 	t.Run("ResetAPByMAC_NilCAPWAPResponse", func(t *testing.T) {
 		responses := map[string]string{
-			"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:ff": `null`,
+			"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01": `null`,
 		}
 		mockServer := testutil.NewMockServer(testutil.WithSuccessResponses(responses))
 		defer mockServer.Close()
@@ -2122,7 +2122,7 @@ func TestApServiceUnit_ResetAP_EdgeCases(t *testing.T) {
 		service := ap.NewService(testClient.Core().(*core.Client))
 		ctx := testutil.TestContext(t)
 
-		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err == nil {
 			t.Error("Expected error for nil CAPWAP response, got nil")
 		}
@@ -2133,9 +2133,9 @@ func TestApServiceUnit_ResetAP_EdgeCases(t *testing.T) {
 	// genuine absence is covered by ResetAPByMAC_EmptyCAPWAPData and by the 404 arm.
 	t.Run("ResetAPByMAC_RPCNotServed", func(t *testing.T) {
 		responses := map[string]string{
-			"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:ff": `{
+			"Cisco-IOS-XE-wireless-access-point-oper:access-point-oper-data/capwap-data=aa:bb:cc:dd:ee:01": `{
 				"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"name": "Different-AP"
 				}]
 			}`,
@@ -2147,7 +2147,7 @@ func TestApServiceUnit_ResetAP_EdgeCases(t *testing.T) {
 		service := ap.NewService(testClient.Core().(*core.Client))
 		ctx := testutil.TestContext(t)
 
-		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.ResetAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err == nil {
 			t.Error("Expected error for AP not found in CAPWAP data, got nil")
 		}
@@ -2172,7 +2172,7 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 			},
 		),
 		testutil.WithCustomResponse(
-			"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:ff", testutil.ResponseConfig{
+			"Cisco-IOS-XE-wireless-ap-cfg:ap-cfg-data/ap-tags/ap-tag=aa:bb:cc:dd:ee:01", testutil.ResponseConfig{
 				StatusCode: 400,
 				Body:       "Invalid request",
 			},
@@ -2186,7 +2186,7 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 
 	// Test updateAPState error handling
 	t.Run("UpdateAPState_RPCError", func(t *testing.T) {
-		err := service.EnableAPByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		err := service.EnableAPByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err == nil {
 			t.Error("Expected error for failed RPC call, got nil")
 		}
@@ -2194,7 +2194,7 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 
 	// Test updateRadioState error handling
 	t.Run("UpdateRadioState_RPCError", func(t *testing.T) {
-		err := service.EnableRadioByMAC(ctx, "aa:bb:cc:dd:ee:ff", 0, ap.RadioType80211BG)
+		err := service.EnableRadioByMAC(ctx, "aa:bb:cc:dd:ee:01", 0, ap.RadioType80211BG)
 		if err == nil {
 			t.Error("Expected error for failed radio RPC call, got nil")
 		}
@@ -2202,7 +2202,7 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 
 	// Test updateRadioState with a radio type the RPC has no band number for
 	t.Run("UpdateRadioState_UnnumberedRadioType", func(t *testing.T) {
-		err := service.EnableRadioByMAC(ctx, "aa:bb:cc:dd:ee:ff", 0, ap.RadioTypeUWB)
+		err := service.EnableRadioByMAC(ctx, "aa:bb:cc:dd:ee:01", 0, ap.RadioTypeUWB)
 		if err == nil {
 			t.Error("Expected error for an unnumbered radio type, got nil")
 		}
@@ -2210,7 +2210,7 @@ func TestApTagServiceUnit_SetOperations_ErrorHandling(t *testing.T) {
 
 	// Test assignTags error handling
 	t.Run("AssignTags_RPCError", func(t *testing.T) {
-		err := service.AssignSiteTag(ctx, "aa:bb:cc:dd:ee:ff", "test-site")
+		err := service.AssignSiteTag(ctx, "aa:bb:cc:dd:ee:01", "test-site")
 		if err == nil {
 			t.Error("Expected error for failed tag assignment RPC call, got nil")
 		}
@@ -2364,7 +2364,7 @@ func newRPCService(t *testing.T, node string) (ap.Service, *testutil.RESTCONFSer
 
 const testAPTagEntry = `{
 	"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
-		"ap-mac": "aa:bb:cc:dd:ee:ff",
+		"ap-mac": "aa:bb:cc:dd:ee:01",
 		"site-tag": "existing-site",
 		"policy-tag": "existing-policy",
 		"rf-tag": "existing-rf"
@@ -2375,7 +2375,7 @@ const testAPTagEntry = `{
 // the controller omits from the read.
 const testAPTagEntryAtDefault = `{
 	"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
-		"ap-mac": "aa:bb:cc:dd:ee:ff",
+		"ap-mac": "aa:bb:cc:dd:ee:01",
 		"site-tag": "existing-site"
 	}]
 }`
@@ -2383,7 +2383,7 @@ const testAPTagEntryAtDefault = `{
 // TestApServiceUnit_AssignTags_MergeSemantics tests that a tag assignment preserves the tags
 // the caller did not name, because the write replaces the whole entry.
 func TestApServiceUnit_AssignTags_MergeSemantics(t *testing.T) {
-	const apMAC = "aa:bb:cc:dd:ee:ff"
+	const apMAC = "aa:bb:cc:dd:ee:01"
 
 	tests := []struct {
 		name              string
@@ -2470,10 +2470,10 @@ func TestApServiceUnit_AssignTags_MergeSemantics(t *testing.T) {
 // TestApServiceUnit_AssignTags_KeepsPrimingProfile tests that the replacing write carries a
 // priming profile the caller never named, which the write body did not declare before.
 func TestApServiceUnit_AssignTags_KeepsPrimingProfile(t *testing.T) {
-	const apMAC = "aa:bb:cc:dd:ee:ff"
+	const apMAC = "aa:bb:cc:dd:ee:01"
 	const entry = `{
 		"Cisco-IOS-XE-wireless-ap-cfg:ap-tag": [{
-			"ap-mac": "aa:bb:cc:dd:ee:ff",
+			"ap-mac": "aa:bb:cc:dd:ee:01",
 			"site-tag": "existing-site",
 			"policy-tag": "existing-policy",
 			"rf-tag": "existing-rf",
@@ -2524,7 +2524,7 @@ func TestApServiceUnit_SetRadioAdminState_RPCInput_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, server := newRPCService(t, slotAdminNode)
-			err := service.DisableRadioByMAC(t.Context(), "aa:bb:cc:dd:ee:ff", tt.slotID, tt.radioType)
+			err := service.DisableRadioByMAC(t.Context(), "aa:bb:cc:dd:ee:01", tt.slotID, tt.radioType)
 			if err != nil {
 				t.Fatalf("DisableRadioByMAC() error = %v", err)
 			}
@@ -2533,7 +2533,7 @@ func TestApServiceUnit_SetRadioAdminState_RPCInput_Success(t *testing.T) {
 				"mode":     "admin-state-disabled",
 				"slot-id":  float64(tt.slotID),
 				"band":     tt.wantBand,
-				"mac-addr": "aa:bb:cc:dd:ee:ff",
+				"mac-addr": "aa:bb:cc:dd:ee:01",
 			})
 		})
 	}
@@ -2567,7 +2567,7 @@ func TestApServiceUnit_RadioBandNumber_UnnumberedTypes_Error(t *testing.T) {
 	for _, radioType := range unnumbered {
 		t.Run(string(radioType), func(t *testing.T) {
 			service, _ := newRPCService(t, slotAdminNode)
-			if err := service.EnableRadioByMAC(t.Context(), "aa:bb:cc:dd:ee:ff", 0, radioType); err == nil {
+			if err := service.EnableRadioByMAC(t.Context(), "aa:bb:cc:dd:ee:01", 0, radioType); err == nil {
 				t.Errorf("EnableRadioByMAC(%s) error = nil, want a refusal", radioType)
 			}
 		})
@@ -2579,13 +2579,13 @@ func TestApServiceUnit_RadioBandNumber_UnnumberedTypes_Error(t *testing.T) {
 func TestApServiceUnit_SetAPAdminState_RPCInput_Success(t *testing.T) {
 	t.Run("ByMAC", func(t *testing.T) {
 		service, server := newRPCService(t, apAdminNode)
-		if err := service.DisableAPByMAC(t.Context(), "AA-BB-CC-DD-EE-FF"); err != nil {
+		if err := service.DisableAPByMAC(t.Context(), "AA-BB-CC-DD-EE-01"); err != nil {
 			t.Fatalf("DisableAPByMAC() error = %v", err)
 		}
 
 		assertRPCInputLeaves(t, server, map[string]any{
 			"mode":     "admin-state-disabled",
-			"mac-addr": "aa:bb:cc:dd:ee:ff",
+			"mac-addr": "aa:bb:cc:dd:ee:01",
 		})
 	})
 
@@ -2617,11 +2617,11 @@ func TestApServiceUnit_ResetCAPWAP_RPCInput_Success(t *testing.T) {
 
 	t.Run("ByMAC", func(t *testing.T) {
 		service, server := newRPCService(t, capwapResetNode)
-		if err := service.ResetCAPWAPByMAC(t.Context(), "AABBCCDDEEFF"); err != nil {
+		if err := service.ResetCAPWAPByMAC(t.Context(), "AABBCCDDEE01"); err != nil {
 			t.Fatalf("ResetCAPWAPByMAC() error = %v", err)
 		}
 
-		assertRPCInputLeaves(t, server, map[string]any{"mac-addr": "aa:bb:cc:dd:ee:ff"})
+		assertRPCInputLeaves(t, server, map[string]any{"mac-addr": "aa:bb:cc:dd:ee:01"})
 	})
 
 	t.Run("BlankArguments", func(t *testing.T) {
@@ -2641,7 +2641,7 @@ func TestApServiceUnit_StateVocabularies_MockSuccess(t *testing.T) {
 	body := `{
 		"Cisco-IOS-XE-wireless-access-point-oper:capwap-data": [
 			{
-				"wtp-mac": "aa:bb:cc:dd:ee:ff",
+				"wtp-mac": "aa:bb:cc:dd:ee:01",
 				"ap-state": {"ap-admin-state": "adminstate-disabled", "ap-operation-state": "registered"},
 				"ap-mode-data": {"wtp-mode": "local-mode", "ap-sub-mode": "not-configured"}
 			}

--- a/service/ap/service_test.go
+++ b/service/ap/service_test.go
@@ -198,7 +198,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"device-detail": {
 						"static-info": {
 							"board-data": {
-								"wtp-serial-num": "FGL2209B05T",
+								"wtp-serial-num": "TST0000AP01",
 								"wtp-enet-mac": "aa:bb:cc:dd:ee:12"
 							}
 						}
@@ -299,7 +299,7 @@ func TestApServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"device-detail": {
 					"static-info": {
 						"board-data": {
-							"wtp-serial-num": "FGL2209B05T",
+							"wtp-serial-num": "TST0000AP01",
 							"wtp-enet-mac": "aa:bb:cc:dd:ee:12"
 						}
 					}

--- a/service/awips/service_test.go
+++ b/service/awips/service_test.go
@@ -46,7 +46,7 @@ func TestAwipsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-awips-oper:awips-oper-data": {
 				"awips-per-ap-info": [
 					{
-						"ap-mac": "00:11:22:33:44:55",
+						"ap-mac": "aa:bb:cc:dd:ee:01",
 						"awips-status": "enabled",
 						"alarm-count": "0",
 						"forensic-capture-status": "disabled"
@@ -66,7 +66,7 @@ func TestAwipsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-awips-oper:awips-oper-data/awips-per-ap-info": `{
 			"Cisco-IOS-XE-wireless-awips-oper:awips-per-ap-info": [
 				{
-					"ap-mac": "00:11:22:33:44:55",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"awips-status": "enabled",
 					"alarm-count": "0",
 					"forensic-capture-status": "disabled"
@@ -87,7 +87,7 @@ func TestAwipsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-awips-oper:awips-oper-data/awips-ap-dwld-status": `{
 			"Cisco-IOS-XE-wireless-awips-oper:awips-ap-dwld-status": [
 				{
-					"ap-mac": "00:11:22:33:44:55",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"status": "success"
 				}
 			]

--- a/service/ble/service_test.go
+++ b/service/ble/service_test.go
@@ -46,7 +46,7 @@ func TestBleServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-ble-ltx-oper:ble-ltx-oper-data": {
 				"ble-ltx-ap-antenna": [
 					{
-						"ap-mac": "aa:bb:cc:dd:ee:f0",
+						"ap-mac": "aa:bb:cc:dd:ee:01",
 						"ble-slot-id": 0,
 						"ble-antenna-id": 1,
 						"is-ble-antenna-present": true
@@ -54,7 +54,7 @@ func TestBleServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				],
 				"ble-ltx-ap": [
 					{
-						"ap-mac": "aa:bb:cc:dd:ee:f0",
+						"ap-mac": "aa:bb:cc:dd:ee:01",
 						"admin": {
 							"enable": true
 						}
@@ -66,7 +66,7 @@ func TestBleServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-ble-ltx-oper:ble-ltx-oper-data/ble-ltx-ap": `{
 			"Cisco-IOS-XE-wireless-ble-ltx-oper:ble-ltx-ap": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:f0",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"admin": {
 						"enable": true
 					}
@@ -76,7 +76,7 @@ func TestBleServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-ble-ltx-oper:ble-ltx-oper-data/ble-ltx-ap-antenna": `{
 			"Cisco-IOS-XE-wireless-ble-ltx-oper:ble-ltx-ap-antenna": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:f0",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"ble-slot-id": 0,
 					"ble-antenna-id": 1,
 					"is-ble-antenna-present": true
@@ -90,7 +90,7 @@ func TestBleServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-ble-mgmt-oper:ble-mgmt-oper-data": {
 				"ble-mgmt-ap": [
 					{
-						"ap-mac": "aa:bb:cc:dd:ee:f0",
+						"ap-mac": "aa:bb:cc:dd:ee:01",
 						"is-new": false,
 						"cmx-id": "1",
 						"oper-state": true
@@ -108,7 +108,7 @@ func TestBleServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-ble-mgmt-oper:ble-mgmt-oper-data/ble-mgmt-ap": `{
 			"Cisco-IOS-XE-wireless-ble-mgmt-oper:ble-mgmt-ap": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:f0",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"is-new": false,
 					"cmx-id": "1",
 					"oper-state": true

--- a/service/client/service_test.go
+++ b/service/client/service_test.go
@@ -34,7 +34,7 @@ func TestClientServiceUnit_RadioVocabularies_MockSuccess(t *testing.T) {
 					"ewlc-ms-phy-type": "client-dot11be-6ghz-prot",
 					"multilink-info": [
 						{
-							"sta-mac": "aa:bb:cc:dd:ee:ff",
+							"sta-mac": "aa:bb:cc:dd:ee:01",
 							"band": "dot11-6-ghz-band",
 							"radio-type": "dot11-radio-type-6ghz"
 						}
@@ -129,7 +129,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data": `{
 			"Cisco-IOS-XE-wireless-client-oper:client-oper-data": {
 				"common-oper-data": [{
-					"client-mac": "02:40:f1:f7:f7:87",
+					"client-mac": "aa:bb:cc:dd:ee:a1",
 					"ap-name": "TEST-AP01",
 					"ms-ap-slot-id": 0,
 					"ms-radio-type": "client-dot11ax-24ghz-prot",
@@ -168,7 +168,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/common-oper-data": `{
 			"Cisco-IOS-XE-wireless-client-oper:common-oper-data": [{
-				"client-mac": "02:40:f1:f7:f7:87",
+				"client-mac": "aa:bb:cc:dd:ee:a1",
 				"ap-name": "TEST-AP01",
 				"ms-ap-slot-id": 0,
 				"ms-radio-type": "client-dot11ax-24ghz-prot",
@@ -204,9 +204,9 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"vrf-name": ""
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/common-oper-data=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/common-oper-data=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:common-oper-data": [{
-				"client-mac": "02:40:f1:f7:f7:87",
+				"client-mac": "aa:bb:cc:dd:ee:a1",
 				"ap-name": "TEST-AP01",
 				"ms-ap-slot-id": 0,
 				"ms-radio-type": "client-dot11ax-24ghz-prot",
@@ -220,20 +220,20 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/dot11-oper-data": `{
 			"Cisco-IOS-XE-wireless-client-oper:dot11-oper-data": [{
-				"ms-mac-address": "02:40:f1:f7:f7:87",
+				"ms-mac-address": "aa:bb:cc:dd:ee:a1",
 				"dot11-state": "associated",
-				"ms-bssid": "f0:d8:05:2c:41:21",
-				"ap-mac-address": "c4:14:a2:c9:02:70",
+				"ms-bssid": "aa:bb:cc:dd:ee:b1",
+				"ap-mac-address": "aa:bb:cc:dd:ee:02",
 				"current-channel": 11,
 				"ms-wlan-id": 1,
-				"vap-ssid": "labo-wlan",
-				"policy-profile": "labo-wlan-profile",
+				"vap-ssid": "test-wlan",
+				"policy-profile": "test-wlan-profile",
 				"ms-ap-slot-id": 0,
 				"radio-type": "dot11-radio-type-bg",
 				"ms-association-id": 8,
 				"ms-auth-alg-num": "open-system",
 				"ms-reason-code": "reason-none",
-				"ms-assoc-time": "2025-09-17T10:50:37.41636+00:00",
+				"ms-assoc-time": "2024-01-15T10:39:00.416360+00:00",
 				"is-11g-client": true,
 				"ms-supported-rates-str": "54.0",
 				"ms-wifi": {
@@ -257,11 +257,11 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mobility-oper-data": `{
 			"Cisco-IOS-XE-wireless-client-oper:mobility-oper-data": [{
-				"ms-mac-addr": "02:40:f1:f7:f7:87",
+				"ms-mac-addr": "aa:bb:cc:dd:ee:a1",
 				"mm-client-role": "mm-client-role-local",
 				"mm-client-roam-type": "mm-roam-type-none",
 				"mm-instance": 0,
-				"mm-complete-timestamp": "2025-09-17T10:50:37+00:00",
+				"mm-complete-timestamp": "2024-01-15T10:39:00+00:00",
 				"mm-remote-tunnel-ip": "0.0.0.0",
 				"mm-remote-tunnel-sec-ip": "0.0.0.0",
 				"mm-remote-platform-id": 0,
@@ -271,18 +271,18 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/policy-data": `{
 			"Cisco-IOS-XE-wireless-client-oper:policy-data": [{
-				"mac": "02:40:f1:f7:f7:87",
+				"mac": "aa:bb:cc:dd:ee:a1",
 				"res-vlan-id": 800,
 				"res-vlan-name": "LAB-INTERNAL"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/sisf-db-mac": `{
 			"Cisco-IOS-XE-wireless-client-oper:sisf-db-mac": [{
-				"mac-addr": "02:40:f1:f7:f7:87",
+				"mac-addr": "aa:bb:cc:dd:ee:a1",
 				"ipv4-binding": {
 					"ip-key": {
 						"zone-id": 0,
-						"ip-addr": "192.168.0.37"
+						"ip-addr": "192.168.1.101"
 					}
 				},
 				"ipv6-binding": [{
@@ -295,7 +295,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/traffic-stats": `{
 			"Cisco-IOS-XE-wireless-client-oper:traffic-stats": [{
-				"ms-mac-address": "02:40:f1:f7:f7:87",
+				"ms-mac-address": "aa:bb:cc:dd:ee:a1",
 				"bytes-rx": "37085614",
 				"bytes-tx": "291727367",
 				"policy-errs": "0",
@@ -323,53 +323,53 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			}]
 		}`,
 		// Add MAC query responses for all *ByMAC functions with real WNC data
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/dc-info=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/dc-info=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:dc-info": []
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/dot11-oper-data=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/dot11-oper-data=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:dot11-oper-data": [{
-				"ms-mac-address": "02:40:f1:f7:f7:87",
+				"ms-mac-address": "aa:bb:cc:dd:ee:a1",
 				"dot11-state": "associated",
 				"current-channel": 11,
 				"ms-wlan-id": 1,
-				"vap-ssid": "labo-wlan",
-				"policy-profile": "labo-wlan-profile"
+				"vap-ssid": "test-wlan",
+				"policy-profile": "test-wlan-profile"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mm-if-client-history=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mm-if-client-history=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:mm-if-client-history": []
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mm-if-client-stats=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mm-if-client-stats=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:mm-if-client-stats": []
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mobility-oper-data=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/mobility-oper-data=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:mobility-oper-data": [{
-				"ms-mac-addr": "02:40:f1:f7:f7:87",
+				"ms-mac-addr": "aa:bb:cc:dd:ee:a1",
 				"mm-client-role": "mm-client-role-local",
 				"mm-client-roam-type": "mm-roam-type-none"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/policy-data=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/policy-data=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:policy-data": [{
-				"mac": "02:40:f1:f7:f7:87",
+				"mac": "aa:bb:cc:dd:ee:a1",
 				"res-vlan-id": 800,
 				"res-vlan-name": "LAB-INTERNAL"
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/sisf-db-mac=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/sisf-db-mac=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:sisf-db-mac": [{
-				"mac-addr": "02:40:f1:f7:f7:87",
+				"mac-addr": "aa:bb:cc:dd:ee:a1",
 				"ipv4-binding": {
 					"ip-key": {
 						"zone-id": 0,
-						"ip-addr": "192.168.0.37"
+						"ip-addr": "192.168.1.101"
 					}
 				}
 			}]
 		}`,
-		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/traffic-stats=02:40:f1:f7:f7:87": `{
+		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/traffic-stats=aa:bb:cc:dd:ee:a1": `{
 			"Cisco-IOS-XE-wireless-client-oper:traffic-stats": [{
-				"ms-mac-address": "02:40:f1:f7:f7:87",
+				"ms-mac-address": "aa:bb:cc:dd:ee:a1",
 				"bytes-rx": "37085614",
 				"bytes-tx": "291727367",
 				"most-recent-rssi": -42,
@@ -408,7 +408,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 	}
 
 	// Test GetCommonInfoByMAC with real WNC MAC address
-	commonByMAC, err := service.GetCommonInfoByMAC(ctx, "02:40:f1:f7:f7:87")
+	commonByMAC, err := service.GetCommonInfoByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetCommonInfoByMAC failed: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 	}
 
 	// Test all *ByMAC functions with real WNC MAC address
-	dcByMAC, err := service.GetDCInfoByMAC(ctx, "02:40:f1:f7:f7:87")
+	dcByMAC, err := service.GetDCInfoByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetDCInfoByMAC failed: %v", err)
 	}
@@ -490,7 +490,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetDCInfoByMAC")
 	}
 
-	dot11ByMAC, err := service.GetDot11InfoByMAC(ctx, "02:40:f1:f7:f7:87")
+	dot11ByMAC, err := service.GetDot11InfoByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetDot11InfoByMAC failed: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetDot11InfoByMAC")
 	}
 
-	mmifHistoryByMAC, err := service.GetMMIFClientHistoryByMAC(ctx, "02:40:f1:f7:f7:87")
+	mmifHistoryByMAC, err := service.GetMMIFClientHistoryByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetMMIFClientHistoryByMAC failed: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetMMIFClientHistoryByMAC")
 	}
 
-	mmifStatsByMAC, err := service.GetMMIFClientStatsByMAC(ctx, "02:40:f1:f7:f7:87")
+	mmifStatsByMAC, err := service.GetMMIFClientStatsByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetMMIFClientStatsByMAC failed: %v", err)
 	}
@@ -514,7 +514,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetMMIFClientStatsByMAC")
 	}
 
-	mobilityByMAC, err := service.GetMobilityInfoByMAC(ctx, "02:40:f1:f7:f7:87")
+	mobilityByMAC, err := service.GetMobilityInfoByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetMobilityInfoByMAC failed: %v", err)
 	}
@@ -522,7 +522,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetMobilityInfoByMAC")
 	}
 
-	policyByMAC, err := service.GetPolicyInfoByMAC(ctx, "02:40:f1:f7:f7:87")
+	policyByMAC, err := service.GetPolicyInfoByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetPolicyInfoByMAC failed: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetPolicyInfoByMAC")
 	}
 
-	sisfByMAC, err := service.GetSISFDBByMAC(ctx, "02:40:f1:f7:f7:87")
+	sisfByMAC, err := service.GetSISFDBByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetSISFDBByMAC failed: %v", err)
 	}
@@ -538,7 +538,7 @@ func TestClientServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		t.Error("Expected non-nil result from GetSISFDBByMAC")
 	}
 
-	trafficByMAC, err := service.GetTrafficStatsByMAC(ctx, "02:40:f1:f7:f7:87")
+	trafficByMAC, err := service.GetTrafficStatsByMAC(ctx, "aa:bb:cc:dd:ee:a1")
 	if err != nil {
 		t.Errorf("GetTrafficStatsByMAC failed: %v", err)
 	}
@@ -741,14 +741,14 @@ func TestClientServiceUnit_ByMAC_WireForm(t *testing.T) {
 		"00-11-22-33-44-55",
 		"0011.2233.4455",
 		"001122334455",
-		"AA:BB:CC:DD:EE:55",
+		"AA:BB:CC:DD:EE:A2",
 	}
 	wants := map[string]string{
 		"00:11:22:33:44:55": "00:11:22:33:44:55",
 		"00-11-22-33-44-55": "00:11:22:33:44:55",
 		"0011.2233.4455":    "00:11:22:33:44:55",
 		"001122334455":      "00:11:22:33:44:55",
-		"AA:BB:CC:DD:EE:55": "aa:bb:cc:dd:ee:55",
+		"AA:BB:CC:DD:EE:A2": "aa:bb:cc:dd:ee:a2",
 	}
 
 	for _, lookup := range lookups {
@@ -784,11 +784,11 @@ func TestClientServiceUnit_Dot11Operations_MockSuccess(t *testing.T) {
 	responses := map[string]string{
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data": `{
 			"Cisco-IOS-XE-wireless-client-oper:client-oper-data": {
-				"common-oper-data": [{"ms-mac": "aa:bb:cc:dd:ee:ff"}]
+				"common-oper-data": [{"ms-mac": "aa:bb:cc:dd:ee:01"}]
 			}
 		}`,
 		"Cisco-IOS-XE-wireless-client-oper:client-oper-data/dot11-oper-data": `{
-			"Cisco-IOS-XE-wireless-client-oper:dot11-oper-data": [{"ms-mac": "aa:bb:cc:dd:ee:ff"}]
+			"Cisco-IOS-XE-wireless-client-oper:dot11-oper-data": [{"ms-mac": "aa:bb:cc:dd:ee:01"}]
 		}`,
 	}
 
@@ -887,7 +887,7 @@ func TestClientServiceUnit_ReadFailure_ReturnsError(t *testing.T) {
 				t.Error("Expected nil result from ListDot11Info")
 			}
 
-			dot11ByMAC, err := service.GetDot11InfoByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+			dot11ByMAC, err := service.GetDot11InfoByMAC(ctx, "aa:bb:cc:dd:ee:01")
 			if err == nil {
 				t.Error("Expected error from GetDot11InfoByMAC, got nil")
 			}
@@ -925,8 +925,8 @@ func TestClientServiceUnit_DeauthenticateWireForm(t *testing.T) {
 	}{
 		{
 			name: "ByMAC",
-			call: func() error { return service.DeauthenticateByMAC(ctx, "AA:BB:CC:DD:EE:55") },
-			want: `{"input":{"mac-addr":"aa:bb:cc:dd:ee:55"}}`,
+			call: func() error { return service.DeauthenticateByMAC(ctx, "AA:BB:CC:DD:EE:A2") },
+			want: `{"input":{"mac-addr":"aa:bb:cc:dd:ee:a2"}}`,
 		},
 		{
 			name: "ByIP",

--- a/service/cts/service_test.go
+++ b/service/cts/service_test.go
@@ -56,7 +56,7 @@ func TestCtsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-cts-sxp-oper:cts-sxp-oper-data": {
 				"flex-mode-ap-sxp-connection-status": [
 					{
-						"wtp-mac": "00:11:22:33:44:55",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"peer-ip": "192.168.1.1",
 						"conn-mode": "listener"
 					}
@@ -66,7 +66,7 @@ func TestCtsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-cts-sxp-oper:cts-sxp-oper-data/flex-mode-ap-sxp-connection-status": `{
 			"Cisco-IOS-XE-wireless-cts-sxp-oper:flex-mode-ap-sxp-connection-status": [
 				{
-					"wtp-mac": "00:11:22:33:44:55",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"peer-ip": "192.168.1.1",
 					"conn-mode": "listener"
 				}

--- a/service/general/service_test.go
+++ b/service/general/service_test.go
@@ -70,7 +70,7 @@ func TestGeneralServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"intf-id": 0,
 					"mgmt-ip": "192.168.1.100",
 					"net-mask": "255.255.255.0",
-					"mgmt-mac": "aa:bb:cc:dd:ee:ff"
+					"mgmt-mac": "aa:bb:cc:dd:ee:01"
 				}
 			}
 		}`,
@@ -136,7 +136,7 @@ func TestGeneralServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"intf-id": 0,
 				"mgmt-ip": "192.168.1.100",
 				"net-mask": "255.255.255.0",
-				"mgmt-mac": "aa:bb:cc:dd:ee:ff"
+				"mgmt-mac": "aa:bb:cc:dd:ee:01"
 			}
 		}`,
 	}

--- a/service/geolocation/service_test.go
+++ b/service/geolocation/service_test.go
@@ -49,7 +49,7 @@ func TestGeolocationServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"num-ap-gnss": 0,
 					"num-ap-man-height": 0,
 					"num-ap-derived": 0,
-					"last-derivation-timestamp": "2025-09-10T17:04:29.717868+00:00"
+					"last-derivation-timestamp": "2024-01-15T10:36:00.000000+00:00"
 				}
 			}
 		}`,
@@ -58,13 +58,13 @@ func TestGeolocationServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"num-ap-gnss": 0,
 				"num-ap-man-height": 0,
 				"num-ap-derived": 0,
-				"last-derivation-timestamp": "2025-09-10T17:04:29.717868+00:00"
+				"last-derivation-timestamp": "2024-01-15T10:36:00.000000+00:00"
 			}
 		}`,
 		"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data": `{
 			"Cisco-IOS-XE-wireless-geolocation-oper:ap-geo-loc-data": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:f0",
+					"ap-mac": "aa:bb:cc:dd:ee:02",
 					"loc": {
 						"source": "manual",
 						"ellipse": {
@@ -114,7 +114,7 @@ func TestGeolocationServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 	}
 
 	// Test GetAPGeolocationDataByMAC operation (may return 404 if not configured)
-	macResult, err := service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:f0")
+	macResult, err := service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:02")
 	if err != nil {
 		// Geolocation data endpoints may not be supported by all WNC configurations
 		t.Logf("GetAPGeolocationDataByMAC failed (expected for unconfigured geolocation): %v", err)
@@ -141,7 +141,7 @@ func TestGeolocationServiceUnit_GetOperations_IndividualEndpoints(t *testing.T) 
 						"num-ap-gnss": 0,
 						"num-ap-man-height": 0,
 						"num-ap-derived": 1,
-						"last-derivation-timestamp": "2025-09-10T17:04:29.717868+00:00"
+						"last-derivation-timestamp": "2024-01-15T10:36:00.000000+00:00"
 					}
 				}
 			}`,
@@ -157,7 +157,7 @@ func TestGeolocationServiceUnit_GetOperations_IndividualEndpoints(t *testing.T) 
 					"num-ap-gnss": 0,
 					"num-ap-man-height": 0,
 					"num-ap-derived": 1,
-					"last-derivation-timestamp": "2025-09-10T17:04:29.717868+00:00"
+					"last-derivation-timestamp": "2024-01-15T10:36:00.000000+00:00"
 				}
 			}`,
 			testFunction: func(service geolocation.Service, ctx context.Context) (interface{}, error) {
@@ -170,7 +170,7 @@ func TestGeolocationServiceUnit_GetOperations_IndividualEndpoints(t *testing.T) 
 			response: `{
 				"Cisco-IOS-XE-wireless-geolocation-oper:ap-geo-loc-data": [
 					{
-						"ap-mac": "aa:bb:cc:dd:ee:f0",
+						"ap-mac": "aa:bb:cc:dd:ee:02",
 						"loc": {
 							"source": "manual",
 							"ellipse": {
@@ -241,7 +241,7 @@ func TestGeolocationServiceUnit_GetOperations_ErrorHandling(t *testing.T) {
 	}
 
 	// Test that GetAPGeolocationDataByMAC properly handles 404 errors
-	_, err = service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:f0")
+	_, err = service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:02")
 	if err == nil {
 		t.Error("Expected error for 404 response, got nil")
 	}
@@ -251,10 +251,10 @@ func TestGeolocationServiceUnit_GetOperations_ErrorHandling(t *testing.T) {
 func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testing.T) {
 	responses := map[string]string{
 		// Exact path that BuildQueryURL will construct
-		"/restconf/data/Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:f0": `{
+		"/restconf/data/Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:02": `{
 			"Cisco-IOS-XE-wireless-geolocation-oper:ap-geo-loc-data": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:f0",
+					"ap-mac": "aa:bb:cc:dd:ee:02",
 					"loc": {
 						"source": "manual",
 						"ellipse": {
@@ -267,10 +267,10 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 				}
 			]
 		}`,
-		"/restconf/data/Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:ff": `{
+		"/restconf/data/Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-geolocation-oper:ap-geo-loc-data": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"loc": {
 						"source": "derived",
 						"ellipse": {
@@ -284,10 +284,10 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 			]
 		}`,
 		// Also support simplified paths for the mock server
-		"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:f0": `{
+		"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:02": `{
 			"Cisco-IOS-XE-wireless-geolocation-oper:ap-geo-loc-data": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:f0",
+					"ap-mac": "aa:bb:cc:dd:ee:02",
 					"loc": {
 						"source": "manual",
 						"ellipse": {
@@ -300,10 +300,10 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 				}
 			]
 		}`,
-		"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data/ap-geo-loc-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-geolocation-oper:ap-geo-loc-data": [
 				{
-					"ap-mac": "aa:bb:cc:dd:ee:ff",
+					"ap-mac": "aa:bb:cc:dd:ee:01",
 					"loc": {
 						"source": "derived",
 						"ellipse": {
@@ -325,7 +325,7 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 	ctx := testutil.TestContext(t)
 
 	// Test successful GetAPGeolocationDataByMAC with colon format
-	result, err := service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:f0")
+	result, err := service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:02")
 	if err != nil {
 		t.Errorf("Expected success for valid MAC, got error: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 	}
 
 	// Test successful GetAPGeolocationDataByMAC with different MAC format normalization
-	result, err = service.GetAPGeolocationDataByMAC(ctx, "aa-bb-cc-dd-ee-ff")
+	result, err = service.GetAPGeolocationDataByMAC(ctx, "aa-bb-cc-dd-ee-01")
 	if err != nil {
 		t.Errorf("Expected success for dash-separated MAC, got error: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 	}
 
 	// Test successful GetAPGeolocationDataByMAC with uppercase no-separator format
-	result, err = service.GetAPGeolocationDataByMAC(ctx, "AABBCCDDEEFF")
+	result, err = service.GetAPGeolocationDataByMAC(ctx, "AABBCCDDEE01")
 	if err != nil {
 		t.Errorf("Expected success for uppercase no-separator MAC, got error: %v", err)
 	}
@@ -353,10 +353,10 @@ func TestGeolocationServiceUnit_GetOperations_GetAPGeolocationDataByMAC(t *testi
 
 	// Test MAC normalization validation path coverage
 	testMACs := []string{
-		"aA:bB:cC:dD:eE:fF", // Mixed case
-		"28-ac-9e-bb-3c-80", // Dash format
-		"28AC9EBB3C80",      // No separators uppercase
-		"28ac9ebb3c80",      // No separators lowercase
+		"aA:bB:cC:dD:eE:01", // Mixed case
+		"aa-bb-cc-dd-ee-02", // Dash format
+		"AABBCCDDEE02",      // No separators uppercase
+		"aabbccddee02",      // No separators lowercase
 	}
 
 	for _, mac := range testMACs {
@@ -446,7 +446,7 @@ func TestGeolocationServiceUnit_ErrorHandling_NilClient(t *testing.T) {
 	}
 
 	// Test that GetAPGeolocationDataByMAC handles nil client
-	_, err = service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:f0")
+	_, err = service.GetAPGeolocationDataByMAC(ctx, "aa:bb:cc:dd:ee:02")
 	if err == nil {
 		t.Error("Expected error with nil client for GetAPGeolocationDataByMAC, got nil")
 	}
@@ -460,7 +460,7 @@ func TestGeolocationServiceUnit_QuotedDecimal64_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data": {
 				"ap-geo-loc-data": [
 					{
-						"ap-mac": "aa:bb:cc:dd:ee:ff",
+						"ap-mac": "aa:bb:cc:dd:ee:01",
 						"loc": {
 							"source": "gnss",
 							"area-of-uncertainty": 12,
@@ -524,7 +524,7 @@ func TestGeolocationServiceUnit_DeclaredWidths_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-geolocation-oper:geolocation-oper-data": {
 				"ap-geo-loc-data": [
 					{
-						"ap-mac": "aa:bb:cc:dd:ee:ff",
+						"ap-mac": "aa:bb:cc:dd:ee:01",
 						"loc": {
 							"area-of-uncertainty": 4294967295,
 							"ellipse": {"major-axis": 65535, "minor-axis": 65535}

--- a/service/hyperlocation/service_test.go
+++ b/service/hyperlocation/service_test.go
@@ -46,7 +46,7 @@ func TestHyperlocationServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-hyperlocation-oper:hyperlocation-oper-data": {
 				"ewlc-hyperlocation-profile": [
 					{
-						"name": "labo-common",
+						"name": "test-common",
 						"hyperlocation-data": {
 							"hyperlocation-enable": true,
 							"pak-rssi-threshold-detection": -100,
@@ -75,7 +75,7 @@ func TestHyperlocationServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-hyperlocation-oper:hyperlocation-oper-data/ewlc-hyperlocation-profile": `{
 			"Cisco-IOS-XE-wireless-hyperlocation-oper:ewlc-hyperlocation-profile": [
 				{
-					"name": "labo-common",
+					"name": "test-common",
 					"hyperlocation-data": {
 						"hyperlocation-enable": true,
 						"pak-rssi-threshold-detection": -100,

--- a/service/mcast/service_test.go
+++ b/service/mcast/service_test.go
@@ -45,19 +45,19 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mcast-oper:mcast-oper-data": {
 				"flex-mediastream-client-summary": [
 					{
-						"client-mac": "2a:e3:42:8f:06:c8",
+						"client-mac": "aa:bb:cc:dd:ee:a2",
 						"vlan-id": 800,
 						"flex-mcast-client-group": [
 							{
 								"mcast-ip": "224.0.0.251",
 								"stream-name": "-",
-								"ap-mac": "aa:bb:cc:dd:ee:ff",
+								"ap-mac": "aa:bb:cc:dd:ee:01",
 								"is-direct": false
 							},
 							{
 								"mcast-ip": "ff02::fb",
 								"stream-name": "-",
-								"ap-mac": "aa:bb:cc:dd:ee:ff",
+								"ap-mac": "aa:bb:cc:dd:ee:01",
 								"is-direct": false
 							}
 						]
@@ -81,37 +81,37 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mcast-oper:mcast-oper-data/flex-mediastream-client-summary": `{
 			"Cisco-IOS-XE-wireless-mcast-oper:flex-mediastream-client-summary": [
 				{
-					"client-mac": "2a:e3:42:8f:06:c8",
+					"client-mac": "aa:bb:cc:dd:ee:a2",
 					"vlan-id": 800,
 					"flex-mcast-client-group": [
 						{
 							"mcast-ip": "224.0.0.251",
 							"stream-name": "-",
-							"ap-mac": "aa:bb:cc:dd:ee:ff",
+							"ap-mac": "aa:bb:cc:dd:ee:01",
 							"is-direct": false
 						},
 						{
 							"mcast-ip": "ff02::fb",
 							"stream-name": "-",
-							"ap-mac": "aa:bb:cc:dd:ee:ff",
+							"ap-mac": "aa:bb:cc:dd:ee:01",
 							"is-direct": false
 						}
 					]
 				},
 				{
-					"client-mac": "68:db:f5:0f:84:18",
+					"client-mac": "aa:bb:cc:dd:ee:a3",
 					"vlan-id": 800,
 					"flex-mcast-client-group": [
 						{
 							"mcast-ip": "224.0.0.251",
 							"stream-name": "-",
-							"ap-mac": "aa:bb:cc:dd:ee:ff",
+							"ap-mac": "aa:bb:cc:dd:ee:01",
 							"is-direct": false
 						},
 						{
 							"mcast-ip": "ff02::fb",
 							"stream-name": "-",
-							"ap-mac": "aa:bb:cc:dd:ee:ff",
+							"ap-mac": "aa:bb:cc:dd:ee:01",
 							"is-direct": false
 						}
 					]
@@ -163,7 +163,7 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mcast-oper:rrc-history-client-record-data": [
 				{
 					"user-time-stamp": "2023-09-22T15:30:00Z",
-					"client-mac": "aa:bb:cc:dd:ee:ff",
+					"client-mac": "aa:bb:cc:dd:ee:01",
 					"decision": "admit",
 					"reason-code": 0,
 					"stream-name": "test-stream"
@@ -173,7 +173,7 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mcast-oper:mcast-oper-data/rrc-sr-radio-record": `{
 			"Cisco-IOS-XE-wireless-mcast-oper:rrc-sr-radio-record": [
 				{
-					"ap-mac": "11:22:33:44:55:66",
+					"ap-mac": "aa:bb:cc:dd:ee:02",
 					"slot-id": 0,
 					"radio-type": 1,
 					"number-of-admitted": 2
@@ -185,7 +185,7 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				{
 					"stream-name-str": "test-stream",
 					"group-ip": "224.0.1.1",
-					"client-mac": "aa:bb:cc:dd:ee:ff",
+					"client-mac": "aa:bb:cc:dd:ee:01",
 					"decision": "admit"
 				}
 			]
@@ -194,7 +194,7 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mcast-oper:rrc-stream-admit-record": [
 				{
 					"last-updated": "2023-09-22T15:30:00Z",
-					"client-mac": "aa:bb:cc:dd:ee:ff",
+					"client-mac": "aa:bb:cc:dd:ee:01",
 					"dest-ip": "224.0.1.1"
 				}
 			]
@@ -203,7 +203,7 @@ func TestMcastServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mcast-oper:rrc-stream-deny-record": [
 				{
 					"last-updated": "2023-09-22T15:30:00Z",
-					"client-mac": "aa:bb:cc:dd:ee:ff",
+					"client-mac": "aa:bb:cc:dd:ee:01",
 					"dest-ip": "224.0.1.1"
 				}
 			]

--- a/service/mdns/service_test.go
+++ b/service/mdns/service_test.go
@@ -65,7 +65,7 @@ func TestMdnsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 						"any-query": "0",
 						"other-query": "0"
 					},
-					"last-clear-time": "2025-09-06T04:13:50+00:00"
+					"last-clear-time": "2024-01-15T10:30:00+00:00"
 				},
 				"mdns-wlan-stats": [
 					{
@@ -75,7 +75,7 @@ func TestMdnsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 							"pak-received": "0",
 							"pak-dropped": "0"
 						},
-						"last-clear-time": "2025-09-06T04:13:50+00:00"
+						"last-clear-time": "2024-01-15T10:30:00+00:00"
 					},
 					{
 						"wlan-id": 1,
@@ -84,7 +84,7 @@ func TestMdnsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 							"pak-received": "0",
 							"pak-dropped": "0"
 						},
-						"last-clear-time": "2025-09-06T04:14:28+00:00"
+						"last-clear-time": "2024-01-15T10:31:00+00:00"
 					}
 				]
 			}
@@ -120,7 +120,7 @@ func TestMdnsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 					"any-query": "0",
 					"other-query": "0"
 				},
-				"last-clear-time": "2025-09-06T04:13:50+00:00"
+				"last-clear-time": "2024-01-15T10:30:00+00:00"
 			}
 		}`,
 		"Cisco-IOS-XE-wireless-mdns-oper:mdns-oper-data/mdns-wlan-stats": `{
@@ -156,7 +156,7 @@ func TestMdnsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 						"any-query": "0",
 						"other-query": "0"
 					},
-					"last-clear-time": "2025-09-06T04:13:50+00:00"
+					"last-clear-time": "2024-01-15T10:30:00+00:00"
 				},
 				{
 					"wlan-id": 1,
@@ -189,7 +189,7 @@ func TestMdnsServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 						"any-query": "0",
 						"other-query": "0"
 					},
-					"last-clear-time": "2025-09-06T04:14:28+00:00"
+					"last-clear-time": "2024-01-15T10:31:00+00:00"
 				}
 			]
 		}`,

--- a/service/mesh/service_test.go
+++ b/service/mesh/service_test.go
@@ -62,7 +62,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mesh-oper:mesh-oper-data": {
 				"mesh-q-stats": [
 					{
-						"wtp-mac": "00:11:22:33:44:55",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"q-type": "data",
 						"peak-length": 100,
 						"average-len": 50,
@@ -71,8 +71,8 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				],
 				"mesh-dr-stats": [
 					{
-						"wtp-mac": "00:11:22:33:44:55",
-						"neigh-ap-mac": "00:66:77:88:99:aa",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
+						"neigh-ap-mac": "aa:bb:cc:dd:ee:02",
 						"data-rate-index": 1,
 						"tx-success": 1000,
 						"tx-attempts": 1050
@@ -80,7 +80,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				],
 				"mesh-sec-stats": [
 					{
-						"wtp-mac": "00:11:22:33:44:55",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"tx-pkts-total": 5000,
 						"rx-pkts-total": 4800,
 						"rx-pkts-error": 5
@@ -88,7 +88,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				],
 				"mesh-oper-data": [
 					{
-						"wtp-mac": "00:11:22:33:44:55",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"bhaul-slot-id": 0,
 						"configured-role": "MAP",
 						"ap-mode": "bridge"
@@ -99,7 +99,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mesh-oper:mesh-oper-data/mesh-q-stats": `{
 			"Cisco-IOS-XE-wireless-mesh-oper:mesh-q-stats": [
 				{
-					"wtp-mac": "00:11:22:33:44:55",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"q-type": "data",
 					"peak-length": 100,
 					"average-len": 50,
@@ -110,8 +110,8 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mesh-oper:mesh-oper-data/mesh-dr-stats": `{
 			"Cisco-IOS-XE-wireless-mesh-oper:mesh-dr-stats": [
 				{
-					"wtp-mac": "00:11:22:33:44:55",
-					"neigh-ap-mac": "00:66:77:88:99:aa",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
+					"neigh-ap-mac": "aa:bb:cc:dd:ee:02",
 					"data-rate-index": 1,
 					"tx-success": 1000,
 					"tx-attempts": 1050
@@ -121,7 +121,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mesh-oper:mesh-oper-data/mesh-sec-stats": `{
 			"Cisco-IOS-XE-wireless-mesh-oper:mesh-sec-stats": [
 				{
-					"wtp-mac": "00:11:22:33:44:55",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"tx-pkts-total": 5000,
 					"rx-pkts-total": 4800,
 					"rx-pkts-error": 5
@@ -131,7 +131,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mesh-oper:mesh-oper-data/mesh-oper-data": `{
 			"Cisco-IOS-XE-wireless-mesh-oper:mesh-oper-data": [
 				{
-					"wtp-mac": "00:11:22:33:44:55",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"bhaul-slot-id": 0,
 					"configured-role": "MAP",
 					"ap-mode": "bridge"
@@ -166,7 +166,7 @@ func TestMeshServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mesh-global-oper:mesh-ap-tree-data": [
 				{
 					"sector-number": 1,
-					"wtp-mac": "00:11:22:33:44:55",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"mesh-ap-count": 5,
 					"rap-count": 2,
 					"map-count": 3,

--- a/service/mobility/service_test.go
+++ b/service/mobility/service_test.go
@@ -46,7 +46,7 @@ func TestMobilityServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-mobility-cfg:mobility-cfg-data": {
 				"mobility-config": {
 					"local-group": "test-group",
-					"mac-address": "aa:bb:cc:dd:ee:ff"
+					"mac-address": "aa:bb:cc:dd:ee:01"
 				}
 			}
 		}`,
@@ -54,19 +54,19 @@ func TestMobilityServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-mobility-cfg:mobility-cfg-data/mobility-config": `{
 			"Cisco-IOS-XE-wireless-mobility-cfg:mobility-config": {
 				"local-group": "test-group",
-				"mac-address": "aa:bb:cc:dd:ee:ff"
+				"mac-address": "aa:bb:cc:dd:ee:01"
 			}
 		}`,
 
 		// Root operational data
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data": {
-				"ap-cache": [{"ap-mac-address": "aa:bb:cc:dd:ee:ff"}],
+				"ap-cache": [{"ap-mac-address": "aa:bb:cc:dd:ee:01"}],
 				"ap-peer-list": [{"peer-ip": "192.168.1.100"}],
 				"mm-global-data": {"tunnel-count": 5},
 				"mm-if-global-msg-stats": {"total-messages": 1000},
 				"mm-if-global-stats": {"total-events": 500},
-				"mobility-client-data": [{"client-mac": "11:22:33:44:55:66"}],
+				"mobility-client-data": [{"client-mac": "aa:bb:cc:dd:ee:a1"}],
 				"mobility-client-stats": [{"client-events": 10}],
 				"mobility-global-dtls-stats": {"dtls-tunnels": 3},
 				"mobility-global-msg-stats": {"messages-sent": 200},
@@ -78,7 +78,7 @@ func TestMobilityServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		// Individual endpoint responses
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/ap-cache": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:ap-cache": [
-				{"ap-mac-address": "aa:bb:cc:dd:ee:ff", "mobility-role": "anchor"}
+				{"ap-mac-address": "aa:bb:cc:dd:ee:01", "mobility-role": "anchor"}
 			]
 		}`,
 
@@ -111,7 +111,7 @@ func TestMobilityServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/mobility-client-data": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:mobility-client-data": [
-				{"client-mac": "11:22:33:44:55:66", "mobility-status": "local"}
+				{"client-mac": "aa:bb:cc:dd:ee:a1", "mobility-status": "local"}
 			]
 		}`,
 
@@ -440,19 +440,19 @@ func TestMobilityServiceUnit_ListOperations_MockSuccess(t *testing.T) {
 	responses := map[string]string{
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/ap-cache": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:ap-cache": [{
-				"ap-mac": "aa:bb:cc:dd:ee:ff",
+				"ap-mac": "aa:bb:cc:dd:ee:01",
 				"ap-name": "TEST-AP01"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/ap-peer-list": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:ap-peer-list": [{
-				"peer-ip": "192.168.255.1",
+				"peer-ip": "192.168.1.100",
 				"peer-status": "up"
 			}]
 		}`,
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/mm-global-data": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:mm-global-data": {
-				"mm-mac-addr": "00:1e:49:96:4c:ff"
+				"mm-mac-addr": "aa:bb:cc:dd:ee:00"
 			}
 		}`,
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/mm-if-global-stats": `{
@@ -469,7 +469,7 @@ func TestMobilityServiceUnit_ListOperations_MockSuccess(t *testing.T) {
 		}`,
 		"Cisco-IOS-XE-wireless-mobility-oper:mobility-oper-data/mobility-client-data": `{
 			"Cisco-IOS-XE-wireless-mobility-oper:mobility-client-data": [{
-				"client-mac": "aa:bb:cc:dd:ee:ff",
+				"client-mac": "aa:bb:cc:dd:ee:01",
 				"mobility-state": "local"
 			}]
 		}`,

--- a/service/rf/service_test.go
+++ b/service/rf/service_test.go
@@ -30,10 +30,10 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"rf-tags": {
 					"rf-tag": [
 						{
-							"tag-name": "labo-inside",
-							"dot11a-rf-profile-name": "labo-rf-5gh-inside",
-							"dot11b-rf-profile-name": "labo-rf-24gh",
-							"dot11-6ghz-rf-prof-name": "labo-rf-6gh"
+							"tag-name": "test-inside",
+							"dot11a-rf-profile-name": "test-rf-5gh-inside",
+							"dot11b-rf-profile-name": "test-rf-24gh",
+							"dot11-6ghz-rf-prof-name": "test-rf-6gh"
 						},
 						{
 							"tag-name": "default-rf-tag",
@@ -44,7 +44,7 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"rf-profiles": {
 					"rf-profile": [
 						{
-							"profile-name": "labo-rf-5gh-inside",
+							"profile-name": "test-rf-5gh-inside",
 							"rf-band": "dot11-5ghz-band",
 							"description": "RF profile for 5GHz indoor"
 						}
@@ -66,10 +66,10 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-rf-cfg:rf-tags": {
 				"rf-tag": [
 					{
-						"tag-name": "labo-inside",
-						"dot11a-rf-profile-name": "labo-rf-5gh-inside",
-						"dot11b-rf-profile-name": "labo-rf-24gh",
-						"dot11-6ghz-rf-prof-name": "labo-rf-6gh"
+						"tag-name": "test-inside",
+						"dot11a-rf-profile-name": "test-rf-5gh-inside",
+						"dot11b-rf-profile-name": "test-rf-24gh",
+						"dot11-6ghz-rf-prof-name": "test-rf-6gh"
 					},
 					{
 						"tag-name": "default-rf-tag",
@@ -82,7 +82,7 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-rf-cfg:rf-profiles": {
 				"rf-profile": [
 					{
-						"profile-name": "labo-rf-5gh-inside",
+						"profile-name": "test-rf-5gh-inside",
 						"rf-band": "dot11-5ghz-band",
 						"description": "RF profile for 5GHz indoor"
 					}
@@ -109,19 +109,19 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-rrm-oper:rrm-oper-data": {
 				"ap-auto-rf-dot11-data": [
 					{
-						"wtp-mac": "28:ac:9e:bb:3c:80",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"radio-slot-id": 0,
 						"neighbor-radio-info": {
 							"neighbor-radio-list": [
 								{
 									"neighbor-radio-info": {
-										"neighbor-radio-mac": "f0:d8:05:2c:41:20",
+										"neighbor-radio-mac": "aa:bb:cc:dd:ee:02",
 										"neighbor-radio-slot-id": 0,
 										"rssi": -21,
 										"snr": 62,
 										"channel": 11,
 										"power": 18,
-										"group-leader-ip": "192.168.255.4",
+										"group-leader-ip": "192.168.1.100",
 										"chan-width": "radio-neighbor-chan-width-20-mhz",
 										"sensor-covered": false
 									}
@@ -132,7 +132,7 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				],
 				"ap-dot11-radar-data": [
 					{
-						"wtp-mac": "28:ac:9e:bb:3c:80",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"radio-slot-id": 0,
 						"last-radar-on-radio": "1970-01-01T00:00:00+00:00"
 					}
@@ -142,19 +142,19 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-oper:rrm-oper-data/ap-auto-rf-dot11-data": `{
 			"Cisco-IOS-XE-wireless-rrm-oper:ap-auto-rf-dot11-data": [
 				{
-					"wtp-mac": "28:ac:9e:bb:3c:80",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0,
 					"neighbor-radio-info": {
 						"neighbor-radio-list": [
 							{
 								"neighbor-radio-info": {
-									"neighbor-radio-mac": "f0:d8:05:2c:41:20",
+									"neighbor-radio-mac": "aa:bb:cc:dd:ee:02",
 									"neighbor-radio-slot-id": 0,
 									"rssi": -21,
 									"snr": 62,
 									"channel": 11,
 									"power": 18,
-									"group-leader-ip": "192.168.255.4",
+									"group-leader-ip": "192.168.1.100",
 									"chan-width": "radio-neighbor-chan-width-20-mhz",
 									"sensor-covered": false
 								}
@@ -167,7 +167,7 @@ func TestRfServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-oper:rrm-oper-data/ap-dot11-radar-data": `{
 			"Cisco-IOS-XE-wireless-rrm-oper:ap-dot11-radar-data": [
 				{
-					"wtp-mac": "28:ac:9e:bb:3c:80",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0,
 					"last-radar-on-radio": "1970-01-01T00:00:00+00:00"
 				}

--- a/service/rf/tag_service_test.go
+++ b/service/rf/tag_service_test.go
@@ -33,15 +33,15 @@ func TestRfTagServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				"rf-tags": {
 					"rf-tag": [
 						{
-							"tag-name": "labo-inside",
-							"dot11a-rf-profile-name": "labo-rf-5gh-inside",
-							"dot11b-rf-profile-name": "labo-rf-24gh",
-							"dot11-6ghz-rf-prof-name": "labo-rf-6gh"
+							"tag-name": "test-inside",
+							"dot11a-rf-profile-name": "test-rf-5gh-inside",
+							"dot11b-rf-profile-name": "test-rf-24gh",
+							"dot11-6ghz-rf-prof-name": "test-rf-6gh"
 						},
 						{
-							"tag-name": "labo-outside",
-							"dot11a-rf-profile-name": "labo-rf-5gh-outside",
-							"dot11b-rf-profile-name": "labo-rf-24gh"
+							"tag-name": "test-outside",
+							"dot11a-rf-profile-name": "test-rf-5gh-outside",
+							"dot11b-rf-profile-name": "test-rf-24gh"
 						},
 						{
 							"tag-name": "default-rf-tag",
@@ -55,15 +55,15 @@ func TestRfTagServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-rf-cfg:rf-tags": {
 				"rf-tag": [
 					{
-						"tag-name": "labo-inside",
-						"dot11a-rf-profile-name": "labo-rf-5gh-inside",
-						"dot11b-rf-profile-name": "labo-rf-24gh",
-						"dot11-6ghz-rf-prof-name": "labo-rf-6gh"
+						"tag-name": "test-inside",
+						"dot11a-rf-profile-name": "test-rf-5gh-inside",
+						"dot11b-rf-profile-name": "test-rf-24gh",
+						"dot11-6ghz-rf-prof-name": "test-rf-6gh"
 					},
 					{
-						"tag-name": "labo-outside",
-						"dot11a-rf-profile-name": "labo-rf-5gh-outside",
-						"dot11b-rf-profile-name": "labo-rf-24gh"
+						"tag-name": "test-outside",
+						"dot11a-rf-profile-name": "test-rf-5gh-outside",
+						"dot11b-rf-profile-name": "test-rf-24gh"
 					},
 					{
 						"tag-name": "default-rf-tag",
@@ -72,13 +72,13 @@ func TestRfTagServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				]
 			}
 		}`,
-		"Cisco-IOS-XE-wireless-rf-cfg:rf-cfg-data/rf-tags/rf-tag=labo-inside": `{
+		"Cisco-IOS-XE-wireless-rf-cfg:rf-cfg-data/rf-tags/rf-tag=test-inside": `{
 			"Cisco-IOS-XE-wireless-rf-cfg:rf-tag": [
 				{
-					"tag-name": "labo-inside",
-					"dot11a-rf-profile-name": "labo-rf-5gh-inside",
-					"dot11b-rf-profile-name": "labo-rf-24gh",
-					"dot11-6ghz-rf-prof-name": "labo-rf-6gh"
+					"tag-name": "test-inside",
+					"dot11a-rf-profile-name": "test-rf-5gh-inside",
+					"dot11b-rf-profile-name": "test-rf-24gh",
+					"dot11-6ghz-rf-prof-name": "test-rf-6gh"
 				}
 			]
 		}`,
@@ -101,21 +101,21 @@ func TestRfTagServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			t.Error("ListRFTags returned empty result")
 		}
 		// Verify first tag from real data
-		if result[0].TagName != "labo-inside" {
-			t.Errorf("Expected tag name 'labo-inside', got '%s'", result[0].TagName)
+		if result[0].TagName != "test-inside" {
+			t.Errorf("Expected tag name 'test-inside', got '%s'", result[0].TagName)
 		}
 	})
 
 	t.Run("GetRFTag", func(t *testing.T) {
-		result, err := rfTagService.GetRFTag(ctx, "labo-inside")
+		result, err := rfTagService.GetRFTag(ctx, "test-inside")
 		if err != nil {
 			t.Errorf("GetRFTag returned unexpected error: %v", err)
 		}
 		if result == nil {
 			t.Error("GetRFTag returned nil result")
 		}
-		if result != nil && result.TagName != "labo-inside" {
-			t.Errorf("Expected tag name 'labo-inside', got '%s'", result.TagName)
+		if result != nil && result.TagName != "test-inside" {
+			t.Errorf("Expected tag name 'test-inside', got '%s'", result.TagName)
 		}
 	})
 

--- a/service/rfid/service_test.go
+++ b/service/rfid/service_test.go
@@ -48,25 +48,25 @@ func TestRfidServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 			}
 		}`,
 		// Add mock responses for MAC-based queries
-		"Cisco-IOS-XE-wireless-rfid-global-oper:rfid-global-oper-data/rfid-data-detail=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-rfid-global-oper:rfid-global-oper-data/rfid-data-detail=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-rfid-global-oper:rfid-data-detail": [
 				{
-					"rfid-mac-addr": "aa:bb:cc:dd:ee:ff"
+					"rfid-mac-addr": "aa:bb:cc:dd:ee:01"
 				}
 			]
 		}`,
-		"Cisco-IOS-XE-wireless-rfid-oper:rfid-oper-data/rfid-data=aa:bb:cc:dd:ee:ff": `{
+		"Cisco-IOS-XE-wireless-rfid-oper:rfid-oper-data/rfid-data=aa:bb:cc:dd:ee:01": `{
 			"Cisco-IOS-XE-wireless-rfid-oper:rfid-data": [
 				{
-					"rfid-mac-addr": "aa:bb:cc:dd:ee:ff"
+					"rfid-mac-addr": "aa:bb:cc:dd:ee:01"
 				}
 			]
 		}`,
-		"Cisco-IOS-XE-wireless-rfid-global-oper:rfid-global-oper-data/rfid-radio-data=aa:bb:cc:dd:ee:ff,00:25:36:57:ed:cb,0": `{
+		"Cisco-IOS-XE-wireless-rfid-global-oper:rfid-global-oper-data/rfid-radio-data=aa:bb:cc:dd:ee:01,aa:bb:cc:dd:ee:02,0": `{
 			"Cisco-IOS-XE-wireless-rfid-global-oper:rfid-radio-data": [
 				{
-					"rfid-mac-addr": "aa:bb:cc:dd:ee:ff",
-					"ap-mac-addr": "00:25:36:57:ed:cb",
+					"rfid-mac-addr": "aa:bb:cc:dd:ee:01",
+					"ap-mac-addr": "aa:bb:cc:dd:ee:02",
 					"slot": 0
 				}
 			]
@@ -112,7 +112,7 @@ func TestRfidServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 
 	// Test uncovered functions
 	t.Run("GetGlobalDetailByMAC", func(t *testing.T) {
-		result, err := service.GetGlobalDetailByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		result, err := service.GetGlobalDetailByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("GetGlobalDetailByMAC returned unexpected error: %v", err)
 		}
@@ -122,7 +122,7 @@ func TestRfidServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 	})
 
 	t.Run("GetRadioInfo", func(t *testing.T) {
-		result, err := service.GetRadioInfo(ctx, "aa:bb:cc:dd:ee:ff", "00:25:36:57:ed:cb", 0)
+		result, err := service.GetRadioInfo(ctx, "aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02", 0)
 		if err != nil {
 			t.Errorf("GetRadioInfo returned unexpected error: %v", err)
 		}
@@ -132,7 +132,7 @@ func TestRfidServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 	})
 
 	t.Run("GetDetailByMAC", func(t *testing.T) {
-		result, err := service.GetDetailByMAC(ctx, "aa:bb:cc:dd:ee:ff")
+		result, err := service.GetDetailByMAC(ctx, "aa:bb:cc:dd:ee:01")
 		if err != nil {
 			t.Errorf("GetDetailByMAC returned unexpected error: %v", err)
 		}
@@ -204,7 +204,7 @@ func TestRfidServiceUnit_ValidationErrors_InvalidInputs(t *testing.T) {
 	})
 
 	t.Run("GetRadioInfo_InvalidMAC", func(t *testing.T) {
-		result, err := service.GetRadioInfo(ctx, "invalid", "11:22:33:44:55:66", 0)
+		result, err := service.GetRadioInfo(ctx, "invalid", "aa:bb:cc:dd:ee:01", 0)
 		if err == nil {
 			t.Error("Expected validation error for invalid MAC address")
 		}
@@ -214,7 +214,7 @@ func TestRfidServiceUnit_ValidationErrors_InvalidInputs(t *testing.T) {
 	})
 
 	t.Run("GetRadioInfo_InvalidAPMAC", func(t *testing.T) {
-		result, err := service.GetRadioInfo(ctx, "aa:bb:cc:dd:ee:ff", "invalid", 0)
+		result, err := service.GetRadioInfo(ctx, "aa:bb:cc:dd:ee:01", "invalid", 0)
 		if err == nil {
 			t.Error("Expected validation error for invalid AP MAC address")
 		}

--- a/service/rogue/service_test.go
+++ b/service/rogue/service_test.go
@@ -43,37 +43,37 @@ func TestRogueServiceUnit_GetOperations_MockSuccess(t *testing.T) {
 				},
 				"rogue-data": [
 					{
-						"rogue-address": "00:25:36:57:ed:cb",
+						"rogue-address": "aa:bb:cc:dd:ee:f1",
 						"rogue-class-type": "rogue-classtype-unclassified",
 						"rogue-mode": "rogue-state-alert",
 						"rogue-containment-level": 0,
 						"contained": false,
-						"rogue-first-timestamp": "2025-09-10T16:27:41.521656+00:00",
-						"rogue-last-timestamp": "2025-09-10T16:54:41.506309+00:00",
+						"rogue-first-timestamp": "2024-01-15T10:33:00.000000+00:00",
+						"rogue-last-timestamp": "2024-01-15T10:35:00.000000+00:00",
 						"max-detected-rssi": -67,
-						"ssid-max-rssi": "rt500k-57ed8b-3"
+						"ssid-max-rssi": "test-rogue-02"
 					},
 					{
-						"rogue-address": "08:10:86:bf:07:e3",
+						"rogue-address": "aa:bb:cc:dd:ee:f4",
 						"rogue-class-type": "rogue-classtype-unclassified",
 						"rogue-mode": "rogue-state-alert",
 						"rogue-containment-level": 0,
 						"contained": false,
-						"rogue-first-timestamp": "2025-09-09T10:55:03.573664+00:00",
-						"rogue-last-timestamp": "2025-09-10T17:04:41.502126+00:00",
+						"rogue-first-timestamp": "2024-01-15T10:32:00.000000+00:00",
+						"rogue-last-timestamp": "2024-01-15T10:37:00.000000+00:00",
 						"max-detected-rssi": -56,
-						"ssid-max-rssi": "aterm-b5acbb-g"
+						"ssid-max-rssi": "test-rogue-01"
 					}
 				],
 				"rogue-client-data": [
 					{
-						"rogue-client-address": "2a:c5:50:5d:6b:9c",
-						"rogue-client-bssid": "1c:61:b4:10:0e:7f",
+						"rogue-client-address": "aa:bb:cc:dd:ee:f3",
+						"rogue-client-bssid": "aa:bb:cc:dd:ee:f2",
 						"rogue-client-state": "rogue-state-alert",
 						"rogue-client-containment-level": 0,
 						"contained": false,
-						"rogue-client-first-timestamp": "2025-09-10T16:32:41.518791+00:00",
-						"rogue-client-last-timestamp": "2025-09-10T17:05:41.501647+00:00"
+						"rogue-client-first-timestamp": "2024-01-15T10:34:00.000000+00:00",
+						"rogue-client-last-timestamp": "2024-01-15T10:38:00.000000+00:00"
 					}
 				]
 			}
@@ -107,28 +107,28 @@ func TestRogueServiceUnit_ListOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rogue-oper:rogue-oper-data/rogue-data": `{
 			"Cisco-IOS-XE-wireless-rogue-oper:rogue-data": [
 				{
-					"rogue-address": "00:25:36:57:ed:cb",
+					"rogue-address": "aa:bb:cc:dd:ee:f1",
 					"rogue-class-type": "rogue-classtype-unclassified",
 					"rogue-mode": "rogue-state-alert",
 					"rogue-containment-level": 0,
 					"contained": false,
-					"rogue-first-timestamp": "2025-09-10T16:27:41.521656+00:00",
-					"rogue-last-timestamp": "2025-09-10T16:54:41.506309+00:00",
+					"rogue-first-timestamp": "2024-01-15T10:33:00.000000+00:00",
+					"rogue-last-timestamp": "2024-01-15T10:35:00.000000+00:00",
 					"max-detected-rssi": -67,
-					"ssid-max-rssi": "rt500k-57ed8b-3"
+					"ssid-max-rssi": "test-rogue-02"
 				}
 			]
 		}`,
 		"Cisco-IOS-XE-wireless-rogue-oper:rogue-oper-data/rogue-client-data": `{
 			"Cisco-IOS-XE-wireless-rogue-oper:rogue-client-data": [
 				{
-					"rogue-client-address": "2a:c5:50:5d:6b:9c",
-					"rogue-client-bssid": "1c:61:b4:10:0e:7f",
+					"rogue-client-address": "aa:bb:cc:dd:ee:f3",
+					"rogue-client-bssid": "aa:bb:cc:dd:ee:f2",
 					"rogue-client-state": "rogue-state-alert",
 					"rogue-client-containment-level": 0,
 					"contained": false,
-					"rogue-client-first-timestamp": "2025-09-10T16:32:41.518791+00:00",
-					"rogue-client-last-timestamp": "2025-09-10T17:05:41.501647+00:00"
+					"rogue-client-first-timestamp": "2024-01-15T10:34:00.000000+00:00",
+					"rogue-client-last-timestamp": "2024-01-15T10:38:00.000000+00:00"
 				}
 			]
 		}`,
@@ -190,31 +190,31 @@ func TestRogueServiceUnit_ListOperations_MockSuccess(t *testing.T) {
 func TestRogueServiceUnit_GetByMACOperations_MockSuccess(t *testing.T) {
 	// Using real WNC rogue data structure
 	mockServer := testutil.NewMockServer(testutil.WithSuccessResponses(map[string]string{
-		"Cisco-IOS-XE-wireless-rogue-oper:rogue-oper-data/rogue-data=00:25:36:57:ed:cb": `{
+		"Cisco-IOS-XE-wireless-rogue-oper:rogue-oper-data/rogue-data=aa:bb:cc:dd:ee:f1": `{
 			"Cisco-IOS-XE-wireless-rogue-oper:rogue-data": [
 				{
-					"rogue-address": "00:25:36:57:ed:cb",
+					"rogue-address": "aa:bb:cc:dd:ee:f1",
 					"rogue-class-type": "rogue-classtype-unclassified",
 					"rogue-mode": "rogue-state-alert",
 					"rogue-containment-level": 0,
 					"contained": false,
-					"rogue-first-timestamp": "2025-09-10T16:27:41.521656+00:00",
-					"rogue-last-timestamp": "2025-09-10T16:54:41.506309+00:00",
+					"rogue-first-timestamp": "2024-01-15T10:33:00.000000+00:00",
+					"rogue-last-timestamp": "2024-01-15T10:35:00.000000+00:00",
 					"max-detected-rssi": -67,
-					"ssid-max-rssi": "rt500k-57ed8b-3"
+					"ssid-max-rssi": "test-rogue-02"
 				}
 			]
 		}`,
-		"Cisco-IOS-XE-wireless-rogue-oper:rogue-oper-data/rogue-client-data=2a:c5:50:5d:6b:9c": `{
+		"Cisco-IOS-XE-wireless-rogue-oper:rogue-oper-data/rogue-client-data=aa:bb:cc:dd:ee:f3": `{
 			"Cisco-IOS-XE-wireless-rogue-oper:rogue-client-data": [
 				{
-					"rogue-client-address": "2a:c5:50:5d:6b:9c",
-					"rogue-client-bssid": "1c:61:b4:10:0e:7f",
+					"rogue-client-address": "aa:bb:cc:dd:ee:f3",
+					"rogue-client-bssid": "aa:bb:cc:dd:ee:f2",
 					"rogue-client-state": "rogue-state-alert",
 					"rogue-client-containment-level": 0,
 					"contained": false,
-					"rogue-client-first-timestamp": "2025-09-10T16:32:41.518791+00:00",
-					"rogue-client-last-timestamp": "2025-09-10T17:05:41.501647+00:00"
+					"rogue-client-first-timestamp": "2024-01-15T10:34:00.000000+00:00",
+					"rogue-client-last-timestamp": "2024-01-15T10:38:00.000000+00:00"
 				}
 			]
 		}`,
@@ -226,7 +226,7 @@ func TestRogueServiceUnit_GetByMACOperations_MockSuccess(t *testing.T) {
 	ctx := testutil.TestContext(t)
 
 	// Test GetRogueByMAC with valid MAC
-	rogueData, err := service.GetRogueByMAC(ctx, "00:25:36:57:ed:cb")
+	rogueData, err := service.GetRogueByMAC(ctx, "aa:bb:cc:dd:ee:f1")
 	if err != nil {
 		t.Errorf("GetRogueByMAC failed: %v", err)
 		return
@@ -238,7 +238,7 @@ func TestRogueServiceUnit_GetByMACOperations_MockSuccess(t *testing.T) {
 	}
 
 	// Test GetRogueClientByMAC with valid MAC
-	clientData, err := service.GetRogueClientByMAC(ctx, "2a:c5:50:5d:6b:9c")
+	clientData, err := service.GetRogueClientByMAC(ctx, "aa:bb:cc:dd:ee:f3")
 	if err != nil {
 		t.Errorf("GetRogueClientByMAC failed: %v", err)
 		return
@@ -315,10 +315,10 @@ func TestRogueServiceUnit_ByMAC_WireForm(t *testing.T) {
 	service := rogue.NewService(testClient.Core().(*core.Client))
 	ctx := testutil.TestContext(t)
 
-	if _, err := service.GetRogueByMAC(ctx, "00-11-22-33-44-55"); err != nil {
+	if _, err := service.GetRogueByMAC(ctx, "aa-bb-cc-dd-ee-01"); err != nil {
 		t.Fatalf("GetRogueByMAC unexpected error: %v", err)
 	}
-	if _, err := service.GetRogueClientByMAC(ctx, "0011.2233.4466"); err != nil {
+	if _, err := service.GetRogueClientByMAC(ctx, "aabb.ccdd.ee02"); err != nil {
 		t.Fatalf("GetRogueClientByMAC unexpected error: %v", err)
 	}
 
@@ -326,10 +326,10 @@ func TestRogueServiceUnit_ByMAC_WireForm(t *testing.T) {
 	if len(recorded) != 2 {
 		t.Fatalf("Recorded %d requests, want 2", len(recorded))
 	}
-	if got, want := recorded[0].Path, "/restconf/data/"+rogueRoute+"=00:11:22:33:44:55"; got != want {
+	if got, want := recorded[0].Path, "/restconf/data/"+rogueRoute+"=aa:bb:cc:dd:ee:01"; got != want {
 		t.Errorf("GetRogueByMAC wire path = %q, want %q", got, want)
 	}
-	if got, want := recorded[1].Path, "/restconf/data/"+clientRoute+"=00:11:22:33:44:66"; got != want {
+	if got, want := recorded[1].Path, "/restconf/data/"+clientRoute+"=aa:bb:cc:dd:ee:02"; got != want {
 		t.Errorf("GetRogueClientByMAC wire path = %q, want %q", got, want)
 	}
 }
@@ -369,13 +369,13 @@ func TestRogueServiceUnit_ErrorHandling_NilClient(t *testing.T) {
 	}
 
 	// Test GetRogueByMAC with nil client
-	_, err = service.GetRogueByMAC(ctx, "00:25:36:57:ed:cb")
+	_, err = service.GetRogueByMAC(ctx, "aa:bb:cc:dd:ee:f1")
 	if err == nil {
 		t.Error("Expected error with nil client for GetRogueByMAC, got nil")
 	}
 
 	// Test GetRogueClientByMAC with nil client
-	_, err = service.GetRogueClientByMAC(ctx, "2a:c5:50:5d:6b:9c")
+	_, err = service.GetRogueClientByMAC(ctx, "aa:bb:cc:dd:ee:f3")
 	if err == nil {
 		t.Error("Expected error with nil client for GetRogueClientByMAC, got nil")
 	}

--- a/service/rrm/service_test.go
+++ b/service/rrm/service_test.go
@@ -132,19 +132,19 @@ func TestRrmServiceUnit_GetConfigOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-rrm-oper:rrm-oper-data": {
 				"ap-auto-rf-dot11-data": [
 					{
-						"wtp-mac": "aa:bb:cc:dd:ee:ff",
+						"wtp-mac": "aa:bb:cc:dd:ee:01",
 						"radio-slot-id": 0,
 						"neighbor-radio-info": {
 							"neighbor-radio-list": [
 								{
 									"neighbor-radio-info": {
-										"neighbor-radio-mac": "aa:bb:cc:dd:ee:ff",
+										"neighbor-radio-mac": "aa:bb:cc:dd:ee:01",
 										"neighbor-radio-slot-id": 0,
 										"rssi": -19,
 										"snr": 62,
 										"channel": 11,
 										"power": 18,
-										"group-leader-ip": "192.168.255.1"
+										"group-leader-ip": "192.168.1.100"
 									}
 								}
 							]
@@ -169,7 +169,7 @@ func TestRrmServiceUnit_GetConfigOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-global-oper:rrm-global-oper-data/radio-oper-data-24g": `{
 			"Cisco-IOS-XE-wireless-rrm-global-oper:radio-oper-data-24g": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0
 				}
 			]
@@ -177,7 +177,7 @@ func TestRrmServiceUnit_GetConfigOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-global-oper:rrm-global-oper-data/radio-oper-data-5g": `{
 			"Cisco-IOS-XE-wireless-rrm-global-oper:radio-oper-data-5g": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 1
 				}
 			]
@@ -185,7 +185,7 @@ func TestRrmServiceUnit_GetConfigOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-global-oper:rrm-global-oper-data/radio-oper-data-6ghz": `{
 			"Cisco-IOS-XE-wireless-rrm-global-oper:radio-oper-data-6ghz": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 2
 				}
 			]
@@ -194,7 +194,7 @@ func TestRrmServiceUnit_GetConfigOperations_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-oper:rrm-oper-data/ap-auto-rf-dot11-data": `{
 			"Cisco-IOS-XE-wireless-rrm-oper:ap-auto-rf-dot11-data": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0
 				}
 			]
@@ -820,12 +820,12 @@ func TestRrmServiceUnit_OmittedVerdict_MockSuccess(t *testing.T) {
 		"Cisco-IOS-XE-wireless-rrm-oper:rrm-oper-data/radio-slot": `{
 			"Cisco-IOS-XE-wireless-rrm-oper:radio-slot": [
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 0,
 					"radio-data": {"load-prof-passed": false, "coverage-overlap-factor": "0.00"}
 				},
 				{
-					"wtp-mac": "aa:bb:cc:dd:ee:ff",
+					"wtp-mac": "aa:bb:cc:dd:ee:01",
 					"radio-slot-id": 1,
 					"radio-data": {
 						"load-prof-passed": true,

--- a/service/site/tag_service_test.go
+++ b/service/site/tag_service_test.go
@@ -79,8 +79,8 @@ func TestSiteTagServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 			"Cisco-IOS-XE-wireless-site-cfg:site-tag-config": [{
 				"site-tag-name": "test-site",
 				"description": "Test Site for Operations",
-				"ap-join-profile": "labo-common",
-				"flex-profile": "labo-flex",
+				"ap-join-profile": "test-common",
+				"flex-profile": "test-flex",
 				"is-local-site": false
 			}]
 		}`,
@@ -89,8 +89,8 @@ func TestSiteTagServiceUnit_SetOperations_MockSuccess(t *testing.T) {
 				"site-tag-config": [{
 					"site-tag-name": "test-site",
 					"description": "Test Site for Operations",
-					"ap-join-profile": "labo-common",
-					"flex-profile": "labo-flex",
+					"ap-join-profile": "test-common",
+					"flex-profile": "test-flex",
 					"is-local-site": false
 				}]
 			}
@@ -236,9 +236,9 @@ func TestSiteTagServiceUnit_GetOperations_RealWNCData(t *testing.T) {
 			"Cisco-IOS-XE-wireless-site-cfg:site-tag-configs": {
 				"site-tag-config": [
 					{
-						"site-tag-name": "labo-site-flex",
-						"flex-profile": "labo-flex",
-						"ap-join-profile": "labo-common",
+						"site-tag-name": "test-site-flex",
+						"flex-profile": "test-flex",
+						"ap-join-profile": "test-common",
 						"is-local-site": false
 					},
 					{
@@ -250,11 +250,11 @@ func TestSiteTagServiceUnit_GetOperations_RealWNCData(t *testing.T) {
 				]
 			}
 		}`,
-		"Cisco-IOS-XE-wireless-site-cfg:site-cfg-data/site-tag-configs/site-tag-config=labo-site-flex": `{
+		"Cisco-IOS-XE-wireless-site-cfg:site-cfg-data/site-tag-configs/site-tag-config=test-site-flex": `{
 			"Cisco-IOS-XE-wireless-site-cfg:site-tag-config": [{
-				"site-tag-name": "labo-site-flex",
-				"flex-profile": "labo-flex",
-				"ap-join-profile": "labo-common",
+				"site-tag-name": "test-site-flex",
+				"flex-profile": "test-flex",
+				"ap-join-profile": "test-common",
 				"is-local-site": false
 			}]
 		}`,
@@ -280,16 +280,16 @@ func TestSiteTagServiceUnit_GetOperations_RealWNCData(t *testing.T) {
 	ctx := testutil.TestContext(t)
 
 	t.Run("GetSiteTag_RealDataStructure", func(t *testing.T) {
-		// Test with labo-site-flex (has flex-profile)
-		result, err := siteTagService.GetSiteTag(ctx, "labo-site-flex")
+		// Test with test-site-flex (has flex-profile)
+		result, err := siteTagService.GetSiteTag(ctx, "test-site-flex")
 		if err != nil {
-			t.Errorf("GetSiteTag failed for labo-site-flex: %v", err)
+			t.Errorf("GetSiteTag failed for test-site-flex: %v", err)
 		}
 		if result == nil {
 			t.Error("Expected site tag result, got nil")
 		}
-		if result != nil && result.SiteTagName != "labo-site-flex" {
-			t.Errorf("Expected site tag name 'labo-site-flex', got %s", result.SiteTagName)
+		if result != nil && result.SiteTagName != "test-site-flex" {
+			t.Errorf("Expected site tag name 'test-site-flex', got %s", result.SiteTagName)
 		}
 
 		// Test with default-site-tag (has description)
@@ -323,13 +323,13 @@ func TestSiteTagServiceUnit_GetOperations_RealWNCData(t *testing.T) {
 		}
 
 		// Verify real data structure fields
-		hasLaboSite := false
+		hasFlexSite := false
 		hasDefaultSite := false
 		for _, tag := range results {
-			if tag.SiteTagName == "labo-site-flex" {
-				hasLaboSite = true
-				if tag.FlexProfile == nil || *tag.FlexProfile != "labo-flex" {
-					t.Error("Expected labo-site-flex to have flex-profile 'labo-flex'")
+			if tag.SiteTagName == "test-site-flex" {
+				hasFlexSite = true
+				if tag.FlexProfile == nil || *tag.FlexProfile != "test-flex" {
+					t.Error("Expected test-site-flex to have flex-profile 'test-flex'")
 				}
 			}
 			if tag.SiteTagName == "default-site-tag" {
@@ -339,8 +339,8 @@ func TestSiteTagServiceUnit_GetOperations_RealWNCData(t *testing.T) {
 				}
 			}
 		}
-		if !hasLaboSite {
-			t.Error("Expected to find labo-site-flex in results")
+		if !hasFlexSite {
+			t.Error("Expected to find test-site-flex in results")
 		}
 		if !hasDefaultSite {
 			t.Error("Expected to find default-site-tag in results")
@@ -416,8 +416,8 @@ func TestSiteTagServiceUnit_SetOperations_AdvancedScenarios(t *testing.T) {
 			"Cisco-IOS-XE-wireless-site-cfg:site-tag-config": [{
 				"site-tag-name": "test-site",
 				"description": "Test Site for Operations",
-				"ap-join-profile": "labo-common",
-				"flex-profile": "labo-flex",
+				"ap-join-profile": "test-common",
+				"flex-profile": "test-flex",
 				"is-local-site": false
 			}]
 		}`,
@@ -426,8 +426,8 @@ func TestSiteTagServiceUnit_SetOperations_AdvancedScenarios(t *testing.T) {
 				"site-tag-config": [{
 					"site-tag-name": "test-site",
 					"description": "Test Site for Operations",
-					"ap-join-profile": "labo-common",
-					"flex-profile": "labo-flex",
+					"ap-join-profile": "test-common",
+					"flex-profile": "test-flex",
 					"is-local-site": false
 				}]
 			}

--- a/service/wlan/service_test.go
+++ b/service/wlan/service_test.go
@@ -608,7 +608,7 @@ func newRecordingService(t *testing.T, body string) (Service, *queryRecorder) {
 	parsed, err := url.Parse(server.URL)
 	assert.AssertNoError(t, err, "parse test server URL")
 
-	client, err := core.New(parsed.Host, "test-token", core.WithInsecureSkipVerify(true))
+	client, err := core.New(parsed.Host, "test-token-123", core.WithInsecureSkipVerify(true))
 	assert.AssertNoError(t, err, "create core client")
 
 	return NewService(client), recorder

--- a/tests/integration/ap_service_test.go
+++ b/tests/integration/ap_service_test.go
@@ -50,7 +50,7 @@ func TestAPServiceIntegration_GetConfigOperations_Success(t *testing.T) {
 			{
 				Name: "GetTagConfigByMAC",
 				Method: func(ctx context.Context, service any) (any, error) {
-					return service.(ap.Service).GetTagConfigByMAC(ctx, "28:ac:9e:11:48:10")
+					return service.(ap.Service).GetTagConfigByMAC(ctx, "aa:bb:cc:dd:ee:02")
 				},
 				LogResult: true,
 			},
@@ -292,7 +292,7 @@ func TestAPServiceIntegration_GetOperationalOperations_Success(t *testing.T) {
 			{
 				Name: "ListAPHistoryByEthernetMAC",
 				Method: func(ctx context.Context, service any) (any, error) {
-					return service.(ap.Service).ListAPHistoryByEthernetMAC(ctx, "28:ac:9e:11:48:10")
+					return service.(ap.Service).ListAPHistoryByEthernetMAC(ctx, "aa:bb:cc:dd:ee:02")
 				},
 				LogResult: true,
 			},
@@ -473,7 +473,7 @@ func TestAPServiceIntegration_AdvancedFilterOperations_Success(t *testing.T) {
 				Name: "GetRadioNeighborByAPMACSlotAndBSSID_EmptyMAC",
 				Method: func(ctx context.Context, service any) error {
 					_, err := service.(ap.Service).GetRadioNeighborByAPMACSlotAndBSSID(
-						ctx, "", 0, "aa:bb:cc:dd:ee:ff")
+						ctx, "", 0, "aa:bb:cc:dd:ee:01")
 					return err
 				},
 				ExpectedError: true,
@@ -493,7 +493,7 @@ func TestAPServiceIntegration_AdvancedFilterOperations_Success(t *testing.T) {
 				Name: "GetRadioNeighborByAPMACSlotAndBSSID_InvalidMAC",
 				Method: func(ctx context.Context, service any) error {
 					_, err := service.(ap.Service).GetRadioNeighborByAPMACSlotAndBSSID(
-						ctx, "invalid-mac", 0, "aa:bb:cc:dd:ee:ff")
+						ctx, "invalid-mac", 0, "aa:bb:cc:dd:ee:01")
 					return err
 				},
 				ExpectedError: true,

--- a/tests/integration/rogue_service_test.go
+++ b/tests/integration/rogue_service_test.go
@@ -74,7 +74,7 @@ func TestRogueServiceIntegration_GetOperationalOperations_Success(t *testing.T) 
 			{
 				Name: "GetRogueClientByMAC",
 				Method: func(ctx context.Context, service any) (any, error) {
-					return service.(rogue.Service).GetRogueClientByMAC(ctx, "00:11:22:33:44:66")
+					return service.(rogue.Service).GetRogueClientByMAC(ctx, "aa:bb:cc:dd:ee:02")
 				},
 				ExpectNotFound: true,
 			},

--- a/wnc_test.go
+++ b/wnc_test.go
@@ -32,41 +32,41 @@ func TestNewClient(t *testing.T) {
 		{
 			name:        "ValidClient",
 			host:        "192.168.1.100",
-			token:       "YWRtaW46cGFzc3dvcmQ=", // base64 encoded "admin:password"
+			token:       "test-token-123", // base64 encoded "admin:password"
 			opts:        nil,
 			expectError: false,
 		},
 		{
 			name:        "ValidClientWithOptions",
-			host:        "wnc.example.internal",
-			token:       "YWRtaW46cGFzc3dvcmQ=",
+			host:        "wnc1.example.internal",
+			token:       "test-token-123",
 			opts:        []Option{WithTimeout(30 * time.Second), WithInsecureSkipVerify(true)},
 			expectError: false,
 		},
 		{
 			name:        "ValidClientWithLoggerAndUserAgent",
-			host:        "controller.example.internal",
-			token:       "YWRtaW46cGFzc3dvcmQ=",
+			host:        "wnc1.example.internal",
+			token:       "test-token-123",
 			opts:        []Option{WithLogger(slog.New(slog.DiscardHandler)), WithUserAgent("custom-agent/1.0")},
 			expectError: false,
 		},
 		{
 			name:        "InvalidHost",
 			host:        "",
-			token:       "YWRtaW46cGFzc3dvcmQ=",
+			token:       "test-token-123",
 			opts:        nil,
 			expectError: true,
 		},
 		{
 			name:        "InvalidToken",
-			host:        "controller.example.com",
+			host:        "wnc1.example.internal",
 			token:       "",
 			opts:        nil,
 			expectError: true,
 		},
 		{
 			name:  "ValidClientWithTransportOptions",
-			host:  "controller.example.internal",
+			host:  "wnc1.example.internal",
 			token: "test-token-123",
 			opts: []Option{
 				WithProxy(http.ProxyFromEnvironment),
@@ -77,7 +77,7 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:  "RejectsNonPositiveResponseHeaderTimeout",
-			host:  "controller.example.internal",
+			host:  "wnc1.example.internal",
 			token: "test-token-123",
 			opts: []Option{
 				WithResponseHeaderTimeout(0),
@@ -86,7 +86,7 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:  "RejectsNonPositiveTLSHandshakeTimeout",
-			host:  "controller.example.internal",
+			host:  "wnc1.example.internal",
 			token: "test-token-123",
 			opts: []Option{
 				WithTLSHandshakeTimeout(-1 * time.Second),
@@ -95,7 +95,7 @@ func TestNewClient(t *testing.T) {
 		},
 		{
 			name:  "NilProxyResolverIsAccepted",
-			host:  "controller.example.internal",
+			host:  "wnc1.example.internal",
 			token: "test-token-123",
 			opts: []Option{
 				WithProxy(nil),
@@ -129,7 +129,7 @@ func TestNewClient(t *testing.T) {
 
 // TestClientServiceAccessors tests that all service accessors return non-nil services.
 func TestClientServiceAccessors(t *testing.T) {
-	client, err := NewClient("controller.example.com", "dGVzdDp0ZXN0")
+	client, err := NewClient("wnc1.example.internal", "test-token-123")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -195,7 +195,7 @@ func newRecordingClient(t *testing.T, body string) (*Client, *mock.RESTCONFServe
 		t.Fatalf("Failed to parse test server URL: %v", err)
 	}
 
-	client, err := NewClient(parsed.Host, "dGVzdDp0ZXN0", WithInsecureSkipVerify(true))
+	client, err := NewClient(parsed.Host, "test-token-123", WithInsecureSkipVerify(true))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestWithDefaultsWireQuery(t *testing.T) {
 		t.Fatalf("Failed to parse test server URL: %v", err)
 	}
 
-	client, err := NewClient(parsed.Host, "dGVzdDp0ZXN0", WithInsecureSkipVerify(true))
+	client, err := NewClient(parsed.Host, "test-token-123", WithInsecureSkipVerify(true))
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -514,7 +514,7 @@ func newRecorder(t *testing.T) (*Client, *[]seenRequest) {
 		t.Fatalf("parsing the recorder URL: %v", err)
 	}
 
-	client, err := NewClient(parsed.Host, "dGVzdDp0ZXN0", WithInsecureSkipVerify(true))
+	client, err := NewClient(parsed.Host, "test-token-123", WithInsecureSkipVerify(true))
 	if err != nil {
 		t.Fatalf("building a client against the recorder: %v", err)
 	}


### PR DESCRIPTION
## WHAT

Gives every test fixture one canonical identity. Access tokens, AP names, controller hostnames and hardware addresses each carried several competing values; they now come from a single scheme documented in `docs/TESTING.md`. The gitleaks allowlists that existed only to permit the retired token literals are removed alongside it.

**The scheme.** MAC addresses come from one locally administered block, `aa:bb:cc:dd:ee:00/40`, whose last octet encodes the device role, so `TEST-AP01` always pairs with `aa:bb:cc:dd:ee:01`. Hostnames resolve to `wnc1.example.internal`, the access token is `test-token-123`, addresses sit in `192.168.1.0/24`, and tag, profile and SSID names take a `test-` prefix.

**Two things a reviewer should weigh.** First, 41 distinct MAC values became 25, and the bit check behind that is worth confirming: four of the retired values were multicast, carrying the I/G bit that stops an address naming a station at all, and 21 fell inside real vendor OUI ranges. Every fixture address that remains is unicast and locally administered. Second, several values had been carried over from live captures rather than written for the tests, including some describing equipment that is not ours to publish; `docs/TESTING.md` now states the rule and names the redaction helper that a hand-pasted value bypasses.

**Deliberately out of scope.** Format-parsing tests (`internal/validation`, `internal/service/mac_test.go`, the spelling table in `service/client`) assert how a MAC is normalized rather than which device it names, so they keep `00:11:22:33:44:55` and its hyphen, dotted and bare spellings. The absence tests in `service/ap` keep `00:00:00:00:00:01` and the `-CONTROL` name suffix, which mark the control group proving a container was reached. `tests/testutil/integration` keeps its own redaction inputs.

## WHY

Fixture identities had drifted far enough that a reader could not tell which value named which device, and material carried over from live captures had accumulated alongside them. Documenting one scheme makes both problems fixable once rather than case by case.

## CHECKS

- [ ] Require Integration Test Support <!-- maintainers will perform integration test and coverage analysis. -->

---

<details>
<summary>Verification</summary>

| Gate | Result |
| ---------------------------- | --------------------- |
| `make lint` | 0 errors |
| `make test-unit` | Success |
| `go test -race ./...` | Pass, 43 packages |
| `pre-commit run --all-files` | 4 hooks passed |
| `gitleaks git` | No leaks, 198 commits |
| `gitleaks dir .` | No leaks |

Two checks specific to this change. Every resulting MAC was re-tested for the I/G and U/L bits: all 25 are unicast and locally administered. And the gitleaks config was tested adversarially — re-adding a retired placeholder to `README.md` is now **caught**, where the path-scoped allowlist used to permit it, while emptying `.gitleaksignore` surfaces exactly the 9 findings its 9 entries pin, so no line in it is dead.

</details>

<details>
<summary>Note on history</summary>

Removing the `.gitleaks.toml` allowlists exposes four findings that survive only in history, so they move to `.gitleaksignore` as commit-pinned fingerprints — an allowlist would silence the value in future commits too, which is what the config's own comment warns against. Each fingerprint group is annotated with what its base64 decodes to. The comment has to sit on its own line: gitleaks reads a whole line as the fingerprint, so a trailing `# ...` breaks the match and the finding returns.

History itself is not rewritten, by prior decision, so what this PR removes remains reachable in earlier commits.

</details>
